### PR TITLE
fix(LT-4284): bump RabbitMQ.Client -> 6.4.0

### DIFF
--- a/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
+++ b/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
@@ -27,16 +27,16 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
-    <PackageReference Include="MessagePack" Version="1.7.3.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.6.4" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Autofac" Version="6.4.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
+    <PackageReference Include="MessagePack" Version="1.9.11" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="protobuf-net" Version="2.3.13" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.2.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Label="dotnet pack instructions">

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IEventContext.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IEventContext.cs
@@ -1,12 +1,16 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
-using RabbitMQ.Client.Events;
+using JetBrains.Annotations;
+using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Middleware
 {
     public interface IEventContext<out T>
     {
-        BasicDeliverEventArgs BasicDeliverEventArgs { get; }
+        ReadOnlyMemory<byte> Body { get; }
+        
+        [CanBeNull] IBasicProperties BasicProperties { get; }
 
         T Event { get; }
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IMiddlewareQueue.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IMiddlewareQueue.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
-using RabbitMQ.Client.Events;
+using JetBrains.Annotations;
+using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Middleware
 {
@@ -9,7 +11,8 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
         void AddMiddleware(IEventMiddleware<T> middleware);
 
         Task RunMiddlewaresAsync(
-            BasicDeliverEventArgs basicDeliverEventArgs,
+            ReadOnlyMemory<byte> body,
+            [CanBeNull] IBasicProperties properties,
             T evt,
             IMessageAcceptor ma,
             CancellationToken cancellationToken);

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/MiddlewareQueue.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/MiddlewareQueue.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using RabbitMQ.Client.Events;
+using JetBrains.Annotations;
+using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Middleware
 {
@@ -23,13 +24,15 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
         }
 
         public Task RunMiddlewaresAsync(
-            BasicDeliverEventArgs basicDeliverEventArgs,
+            ReadOnlyMemory<byte> body,
+            [CanBeNull] IBasicProperties properties,
             T evt,
             IMessageAcceptor ma,
             CancellationToken cancellationToken)
         {
             var context = new EventContext<T>(
-                basicDeliverEventArgs,
+                body,
+                properties,
                 evt,
                 ma,
                 _settings,

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/Telemetry/TelemetryMiddleware.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/Telemetry/TelemetryMiddleware.cs
@@ -20,7 +20,7 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware.Telemetry
             if (_queueName == null)
                 _queueName = context.Settings.GetQueueOrExchangeName();
 
-            var telemetryOperation = InitTelemetryOperation(_queueName, context.BasicDeliverEventArgs.Body.Length);
+            var telemetryOperation = InitTelemetryOperation(_queueName, context.Body.Length);
             try
             {
                 return context.InvokeNextAsync();

--- a/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
+++ b/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
@@ -12,13 +12,13 @@ namespace TestInvoke.SubscribeExample
 {
     public static class HowToSubscribe
     {
-        private static RabbitMqSubscriber<string> _connector;
+        private static RabbitMqPullingSubscriber<string> _connector;
 
         public static void Example(RabbitMqSubscriptionSettings settings)
         {
             _connector =
-                new RabbitMqSubscriber<string>(
-                    new NullLogger<RabbitMqSubscriber<string>>(),
+                new RabbitMqPullingSubscriber<string>(
+                    new NullLogger<RabbitMqPullingSubscriber<string>>(),
                     settings)
                     .UseMiddleware(new ExceptionSwallowMiddleware<string>(new NullLogger<ExceptionSwallowMiddleware<string>>()))
                     .SetMessageDeserializer(new TestMessageDeserializer())

--- a/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
@@ -38,22 +38,16 @@ namespace Lykke.RabbitMqBroker.Tests.Deduplication
             middlewarequeue.AddMiddleware(lastMiddleware);
 
             middlewarequeue.RunMiddlewaresAsync(
-                new BasicDeliverEventArgs
-                {
-                    BasicProperties = new BasicProperties(),
-                    Body = value
-                },
-                null,
-                acceptor,
-                CancellationToken.None)
+                    value,
+                    null,
+                    null,
+                    acceptor,
+                    CancellationToken.None)
                 .GetAwaiter().GetResult();
 
             middlewarequeue.RunMiddlewaresAsync(
-                    new BasicDeliverEventArgs
-                    {
-                        BasicProperties = new BasicProperties(),
-                        Body = value
-                    },
+                    value,
+                    null,
                     null,
                     acceptor,
                     CancellationToken.None)

--- a/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
@@ -36,7 +36,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => Task.CompletedTask));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             acceptor.Received(1).Accept();
         }
@@ -51,7 +51,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => throw new Exception()));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             rootEventMiddlewareHandler.Received(1).ProcessAsync(Arg.Any<IEventContext<string>>());
         }

--- a/tests/Lykke.RabbitMqBroker.Tests/Lykke.RabbitMqBroker.Tests.csproj
+++ b/tests/Lykke.RabbitMqBroker.Tests/Lykke.RabbitMqBroker.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Lykke.RabbitMqBroker\Lykke.RabbitMqBroker.csproj" />

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqClusterSubsriberTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqClusterSubsriberTest.cs
@@ -27,7 +27,7 @@ namespace Lykke.RabbitMqBroker.Tests
         protected const string ExchangeName = "TestClusterExchange";
         protected const string QueueName = "TestClusterQueue";
 
-        private RabbitMqSubscriber<string> _subscriber;
+        private RabbitMqPullingSubscriber<string> _pullingSubscriber;
         private int _messagesCount;
 
         [Test]
@@ -41,8 +41,8 @@ namespace Lykke.RabbitMqBroker.Tests
                 IsDurable = true,
                 QueueName = QueueName
             };
-            _subscriber = new RabbitMqSubscriber<string>(
-                    new NullLogger<RabbitMqSubscriber<string>>(),
+            _pullingSubscriber = new RabbitMqPullingSubscriber<string>(
+                    new NullLogger<RabbitMqPullingSubscriber<string>>(),
                     settings)
                 .UseMiddleware(new InMemoryDeduplicationMiddleware<string>())
                 .UseMiddleware(new ExceptionSwallowMiddleware<string>(new NullLogger<ExceptionSwallowMiddleware<string>>()))
@@ -56,8 +56,8 @@ namespace Lykke.RabbitMqBroker.Tests
                 _messagesCount++;
                 return Task.CompletedTask;
             });
-            _subscriber.Subscribe(handler);
-            _subscriber.Start();
+            _pullingSubscriber.Subscribe(handler);
+            _pullingSubscriber.Start();
 
             // act
             {
@@ -98,8 +98,8 @@ namespace Lykke.RabbitMqBroker.Tests
                 IsDurable = true,
                 QueueName = QueueName
             };
-            _subscriber = new RabbitMqSubscriber<string>(
-                    new NullLogger<RabbitMqSubscriber<string>>(), 
+            _pullingSubscriber = new RabbitMqPullingSubscriber<string>(
+                    new NullLogger<RabbitMqPullingSubscriber<string>>(), 
                     settings)
                 .UseMiddleware(new InMemoryDeduplicationMiddleware<string>())
                 .UseMiddleware(new ExceptionSwallowMiddleware<string>(new NullLogger<ExceptionSwallowMiddleware<string>>()))
@@ -113,8 +113,8 @@ namespace Lykke.RabbitMqBroker.Tests
                 _messagesCount++;
                 return Task.CompletedTask;
             });
-            _subscriber.Subscribe(handler);
-            _subscriber.Start();
+            _pullingSubscriber.Subscribe(handler);
+            _pullingSubscriber.Start();
 
             // act
             {
@@ -137,7 +137,7 @@ namespace Lykke.RabbitMqBroker.Tests
         [TearDown]
         public void TearDown()
         {
-            _subscriber.Stop();
+            _pullingSubscriber.Stop();
         }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
@@ -72,21 +72,19 @@ namespace Lykke.RabbitMqBroker.Tests
             using (var connection = _factory.CreateConnection())
             using (var channel = connection.CreateModel())
             {
-                var consumer = new QueueingBasicConsumer(channel);
-                channel.BasicConsume(queueName, false, consumer);
-                if (consumer.Queue.Dequeue(1000, out var eventArgs))
+                var result = channel.BasicGet(queueName, ack);
+                if (result != null)
                 {
-
                     if (ack)
                     {
-                        channel.BasicAck(eventArgs.DeliveryTag, false);
+                        channel.BasicAck(result.DeliveryTag, false);
                     }
                     else
                     {
-                        channel.BasicReject(eventArgs.DeliveryTag, false);
+                        channel.BasicReject(result.DeliveryTag, false);
                     }
 
-                    return Encoding.UTF8.GetString(eventArgs.Body);
+                    return Encoding.UTF8.GetString(result.Body.ToArray());
                 }
                 return string.Empty;
             }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubsriberTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubsriberTest.cs
@@ -18,13 +18,13 @@ namespace Lykke.RabbitMqBroker.Tests
     [Explicit]
     internal sealed class RabbitMqSubsriberTest : RabbitMqPublisherSubscriberBaseTest
     {
-        private RabbitMqSubscriber<string> _subscriber;
+        private RabbitMqPullingSubscriber<string> _pullingSubscriber;
 
         [SetUp]
         public void SetUp()
         {
-            _subscriber = new RabbitMqSubscriber<string>(
-                    new NullLogger<RabbitMqSubscriber<string>>(),
+            _pullingSubscriber = new RabbitMqPullingSubscriber<string>(
+                    new NullLogger<RabbitMqPullingSubscriber<string>>(),
                     _settings)
                 .UseMiddleware(new ExceptionSwallowMiddleware<string>(new NullLogger<ExceptionSwallowMiddleware<string>>()))
                 .CreateDefaultBinding()
@@ -45,9 +45,9 @@ namespace Lykke.RabbitMqBroker.Tests
                 completeLock.Set();
                 return Task.CompletedTask;
             });
-            _subscriber.Subscribe(handler);
+            _pullingSubscriber.Subscribe(handler);
 
-            _subscriber.Start();
+            _pullingSubscriber.Start();
 
             PublishToQueue(expected);
 
@@ -58,8 +58,8 @@ namespace Lykke.RabbitMqBroker.Tests
         [Test]
         public void ShouldUseDeadLetterQueueOnException()
         {
-            _subscriber = new RabbitMqSubscriber<string>(
-                    new NullLogger<RabbitMqSubscriber<string>>(),
+            _pullingSubscriber = new RabbitMqPullingSubscriber<string>(
+                    new NullLogger<RabbitMqPullingSubscriber<string>>(),
                     _settings)
                 .UseMiddleware(new ExceptionSwallowMiddleware<string>(new NullLogger<ExceptionSwallowMiddleware<string>>()))
                 .CreateDefaultBinding()
@@ -76,8 +76,8 @@ namespace Lykke.RabbitMqBroker.Tests
                 completeLock.Set();
                 throw new Exception();
             });
-            _subscriber.Subscribe(handler);
-            _subscriber.Start();
+            _pullingSubscriber.Subscribe(handler);
+            _pullingSubscriber.Start();
 
             completeLock.Wait();
 
@@ -89,7 +89,7 @@ namespace Lykke.RabbitMqBroker.Tests
         [TearDown]
         public void TearDown()
         {
-            _subscriber.Stop();
+            _pullingSubscriber.Stop();
         }
 
         private void PublishToQueue(string message)

--- a/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
@@ -37,7 +37,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => Task.CompletedTask));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             acceptor.Received(1).Accept();
         }


### PR DESCRIPTION
RabbitMqSubscriber was renamed to RabbitMqPullingSubscriber, EventContext API has been updated. The latest version of RabbitMq.Client library removes the deprecated QueueBasicConsumer in favour of more sustainable ways of getting messages from server. We can't do the same therefore alternative approach was used, we still be using pulling approach. 