### PR TITLE
fix(LT-4284): add dumb basic properties implementation to pass unit t…

### DIFF
--- a/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/BasicPublishStrategyTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/BasicPublishStrategyTests.cs
@@ -52,7 +52,7 @@ namespace Lykke.RabbitMqBroker.Tests.PublisherStrategies
             var settings = RabbitMqSubscriptionSettings.ForPublisher("connectionString", "endpoint");
             var strategy = ctor(settings);
             var channel = new Mock<IModel>();
-            channel.Setup(x => x.CreateBasicProperties()).Returns(new BasicProperties());
+            channel.Setup(x => x.CreateBasicProperties()).Returns(new DumbBasicProperties());
 
             var header = "hello-header";
             var headerValue = "hello-world";

--- a/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/BasicPublishStrategyWithConfirmationsTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/BasicPublishStrategyWithConfirmationsTests.cs
@@ -65,7 +65,7 @@ namespace Lykke.RabbitMqBroker.Tests.PublisherStrategies
             var settings = RabbitMqSubscriptionSettings.ForPublisher("connectionString", "endpoint");
             var strategy = ctor(settings);
             var channel = new Mock<IModel>();
-            channel.Setup(x => x.CreateBasicProperties()).Returns(new BasicProperties());
+            channel.Setup(x => x.CreateBasicProperties()).Returns(new DumbBasicProperties());
 
             var header = "hello-header";
             var headerValue = "hello-world";
@@ -98,7 +98,7 @@ namespace Lykke.RabbitMqBroker.Tests.PublisherStrategies
             var settings = RabbitMqSubscriptionSettings.ForPublisher("connectionString", "endpoint");
             var strategy = ctor(settings);
             var channel = new Mock<IModel>();
-            channel.Setup(x => x.CreateBasicProperties()).Returns(new BasicProperties());
+            channel.Setup(x => x.CreateBasicProperties()).Returns(new DumbBasicProperties());
 
             var header = "hello-header";
             var headerValue = "hello-world";

--- a/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/DumbBasicProperties.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/PublisherStrategies/DumbBasicProperties.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using RabbitMQ.Client;
+
+namespace Lykke.RabbitMqBroker.Tests.PublisherStrategies
+{
+    public class DumbBasicProperties : IBasicProperties
+    {
+        public ushort ProtocolClassId { get; }
+        public string ProtocolClassName { get; }
+        public void ClearAppId()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearClusterId()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearContentEncoding()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearContentType()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearCorrelationId()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearDeliveryMode()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearExpiration()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearHeaders()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearMessageId()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearPriority()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearReplyTo()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearTimestamp()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearType()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void ClearUserId()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsAppIdPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsClusterIdPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsContentEncodingPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsContentTypePresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsCorrelationIdPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsDeliveryModePresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsExpirationPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsHeadersPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsMessageIdPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsPriorityPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsReplyToPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsTimestampPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsTypePresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool IsUserIdPresent()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public string AppId { get; set; }
+        public string ClusterId { get; set; }
+        public string ContentEncoding { get; set; }
+        public string ContentType { get; set; }
+        public string CorrelationId { get; set; }
+        public byte DeliveryMode { get; set; }
+        public string Expiration { get; set; }
+        public IDictionary<string, object> Headers { get; set; }
+        public string MessageId { get; set; }
+        public bool Persistent { get; set; }
+        public byte Priority { get; set; }
+        public string ReplyTo { get; set; }
+        public PublicationAddress ReplyToAddress { get; set; }
+        public AmqpTimestamp Timestamp { get; set; }
+        public string Type { get; set; }
+        public string UserId { get; set; }
+    }
+}


### PR DESCRIPTION
…ests

Latest version of RabbitMq.Client made BasicProperties class internal. Therefore it can't be used directly anymore.