### PR TITLE
fix(LT-4284): use DefaultBasicConsumer

### DIFF
--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
@@ -184,13 +184,16 @@ namespace Lykke.RabbitMqBroker.Subscriber
 
                 var queueName = _messageReadStrategy.Configure(settings, channel);
 
+                var consumer = new DefaultBasicConsumer(channel);
+                var tag = channel.BasicConsume(queueName, false, consumer);
+
                 while (!IsStopped())
                 {
                     if (!connection.IsOpen)
                     {
                         throw new RabbitMqBrokerException($"{settings.GetSubscriberName()}: connection to {connection.Endpoint} is closed");
                     }
-
+                    
                     var result = channel.BasicGet(queueName, false);
 
                     _reconnectionsInARowCount = 0;
@@ -200,6 +203,8 @@ namespace Lykke.RabbitMqBroker.Subscriber
                         MessageReceived(channel, result);
                     }
                 }
+                
+                channel.BasicCancel(tag);
             }
         }
 


### PR DESCRIPTION
DefaultBasicConsumer is used just to formally have a registered subscription in terms of RabbitMQ management dashboard however, the messages reading cycle is still there and uses BasicGet.