### PR TITLE
feat(LT-4955): add PropertiesWithMessageTypeTopicPublishStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2023-08-22)
+
+### Added
+- LT-4955: Add new publishing strategy 'PropertiesWithMessageTypeTopicPublishStrategy'
+
 ## 11.9.3 (2023-08-10)
 
 ### Added

--- a/src/Lykke.RabbitMqBroker/Publisher/Strategies/PropertiesWithMessageTypeTopicPublishStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Strategies/PropertiesWithMessageTypeTopicPublishStrategy.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using RabbitMQ.Client;
+
+namespace Lykke.RabbitMqBroker.Publisher.Strategies
+{
+    public sealed class PropertiesWithMessageTypeTopicPublishStrategy : IRabbitMqPublishStrategy
+    {
+        private readonly bool _durable;
+        private readonly string _routingKey;
+        private readonly string _exchangeName;
+
+        public PropertiesWithMessageTypeTopicPublishStrategy(RabbitMqSubscriptionSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            _routingKey = settings.RoutingKey ?? string.Empty;
+            _durable = settings.IsDurable;
+            _exchangeName = settings.ExchangeName;
+        }
+
+        public void Configure(IModel channel)
+        {
+            channel.ExchangeDeclare(_exchangeName, "topic", _durable);
+        }
+
+        public void Publish(IModel channel, RawMessage message)
+        {
+            IBasicProperties properties = channel.CreateBasicProperties();
+            properties.DeliveryMode = 2;
+            properties.Type = _routingKey;
+            var headers = message.Headers ?? new Dictionary<string, object>();
+            headers.Add("initialRoute", string.Format(CultureInfo.InvariantCulture, @"topic://{0}/{1}", _exchangeName, _routingKey));
+            properties.Headers = new Dictionary<string, object>(headers);
+
+            channel.BasicPublish(
+                _exchangeName,
+                message.RoutingKey ?? _routingKey,
+                properties,
+                message.Body);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new publishing strategy `PropertiesWithMessageTypeTopicPublishStrategy` - which is being used by some of our services.  