### PR TITLE
Lt 4989 improve shared queue

### DIFF
--- a/src/Lykke.RabbitMqBroker/QueueingBasicConsumerNoLock.cs
+++ b/src/Lykke.RabbitMqBroker/QueueingBasicConsumerNoLock.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Lykke.RabbitMqBroker
+{
+    public class QueueingBasicConsumerNoLock : DefaultBasicConsumer
+    {
+        public QueueingBasicConsumerNoLock() : this(null)
+        {
+            
+        }
+
+        public QueueingBasicConsumerNoLock(IModel model) : this(model, new SharedConcurrentQueue<BasicDeliverEventArgs>())
+        {
+            
+        }
+
+        public QueueingBasicConsumerNoLock(IModel model, SharedConcurrentQueue<BasicDeliverEventArgs> queue) : base(model)
+        {
+            Queue = queue;
+        }
+        
+        public SharedConcurrentQueue<BasicDeliverEventArgs> Queue { get; private set; }
+
+        public override void HandleBasicDeliver(string consumerTag,
+            ulong deliveryTag,
+            bool redelivered,
+            string exchange,
+            string routingKey,
+            IBasicProperties properties,
+            ReadOnlyMemory<byte> body)
+        {
+            var bodyCopy = new byte[body.Length];
+            Buffer.BlockCopy(body.ToArray(), 0, bodyCopy, 0, body.Length);
+            
+            var eventArgs = new BasicDeliverEventArgs(consumerTag,
+                deliveryTag,
+                redelivered,
+                exchange,
+                routingKey,
+                properties,
+                new ReadOnlyMemory<byte>(bodyCopy));
+            
+            Queue.Enqueue(eventArgs);
+        }
+
+        public override void OnCancel(params string[] consumerTags)
+        {
+            base.OnCancel(consumerTags);
+            Queue.Close();
+        }
+    }
+}

--- a/src/Lykke.RabbitMqBroker/SharedConcurrentQueue.cs
+++ b/src/Lykke.RabbitMqBroker/SharedConcurrentQueue.cs
@@ -9,7 +9,7 @@ namespace Lykke.RabbitMqBroker
     public class SharedConcurrentQueue<T>
     {
         private bool _isOpen = true;
-        private ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
+        private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         
         public void Enqueue(T item)
         {
@@ -35,7 +35,5 @@ namespace Lykke.RabbitMqBroker
                 throw new EndOfStreamException("SharedConcurrentQueue closed");
             }
         }
-        
-        
     }
 }

--- a/src/Lykke.RabbitMqBroker/SharedConcurrentQueue.cs
+++ b/src/Lykke.RabbitMqBroker/SharedConcurrentQueue.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace Lykke.RabbitMqBroker
+{
+    public class SharedConcurrentQueue<T>
+    {
+        private bool _isOpen = true;
+        private ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
+        
+        public void Enqueue(T item)
+        {
+            EnsureIsOpen();
+            _queue.Enqueue(item);
+        }
+        
+        public bool Dequeue(out T item)
+        {
+            EnsureIsOpen();
+            return _queue.TryDequeue(out item);
+        }
+
+        public void Close()
+        {
+            _isOpen = false;
+        }
+        
+        private void EnsureIsOpen()
+        {
+            if (!_isOpen)
+            {
+                throw new EndOfStreamException("SharedConcurrentQueue closed");
+            }
+        }
+        
+        
+    }
+}

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
@@ -191,7 +191,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
 
                 var queueName = _messageReadStrategy.Configure(settings, channel);
                 
-                var consumer = new QueueingBasicConsumer(channel);
+                var consumer = new QueueingBasicConsumerNoLock(channel);
                 var tag = channel.BasicConsume(queueName, false, consumer);
 
                 while (!IsStopped())
@@ -201,7 +201,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
                         throw new RabbitMqBrokerException($"{settings.GetSubscriberName()}: connection to {connection.Endpoint} is closed");
                     }
                     
-                    var delivered = consumer.Queue.Dequeue(2000, out var eventArgs);
+                    var delivered = consumer.Queue.Dequeue(out var eventArgs);
 
                     _reconnectionsInARowCount = 0;
 


### PR DESCRIPTION
This pull request effectively replaces existing `SharedQueue` used in `QueueingBasicConsumer` with another `SharedConcurrentQueue` which internally uses `ConcurrentQueue` and doesn't need custom locks to be established. This update results in a new `QueueingBasicConsumerNoLock` which is then used in `RabbitMqPullingSubscriber`. 

The purpose is to decrease messages processing timing.