### PR TITLE
Lt 4990 switch to eventing consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2023-09-19)
+
+### Added
+- LT-4990: Add new `EventingBasicConsumerNoLock` to avoid broker pulling
+
 ## 11.10.0 (2023-09-19)
 
 ### Added

--- a/src/Lykke.RabbitMqBroker/EventingBasicConsumerNoLock.cs
+++ b/src/Lykke.RabbitMqBroker/EventingBasicConsumerNoLock.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace Lykke.RabbitMqBroker
+{
+    public class EventingBasicConsumerNoLock : EventingBasicConsumer
+    {
+        public SharedConcurrentQueue<BasicDeliverEventArgs> Queue { get; private set; }
+        
+        private EventingBasicConsumerNoLock(IModel model) : base(model)
+        {
+        }
+        
+        public EventingBasicConsumerNoLock(IModel model, SharedConcurrentQueue<BasicDeliverEventArgs> queue) : base(model)
+        {
+            Queue = queue;
+            Received += OnReceived;
+            Unregistered += OnUnregistered;
+        }
+
+        private void OnUnregistered(object sender, ConsumerEventArgs e)
+        {
+            Queue.Close();
+        }
+
+        private void OnReceived(object sender, BasicDeliverEventArgs e)
+        {
+            var bodyCopy = new byte[e.Body.Length];
+            Buffer.BlockCopy(e.Body.ToArray(), 0, bodyCopy, 0, e.Body.Length);
+            
+            var eventArgs = new BasicDeliverEventArgs(e.ConsumerTag,
+                e.DeliveryTag,
+                e.Redelivered,
+                e.Exchange,
+                e.RoutingKey,
+                e.BasicProperties,
+                new ReadOnlyMemory<byte>(bodyCopy));
+            
+            Queue.Enqueue(eventArgs);
+        }
+    }
+}

--- a/src/Lykke.RabbitMqBroker/EventingBasicConsumerNoLock.cs
+++ b/src/Lykke.RabbitMqBroker/EventingBasicConsumerNoLock.cs
@@ -11,8 +11,13 @@ namespace Lykke.RabbitMqBroker
     {
         public SharedConcurrentQueue<BasicDeliverEventArgs> Queue { get; private set; }
         
-        private EventingBasicConsumerNoLock(IModel model) : base(model)
+        private EventingBasicConsumerNoLock() : base(null)
         {
+        }
+        
+        public EventingBasicConsumerNoLock(IModel model) : this(model, new SharedConcurrentQueue<BasicDeliverEventArgs>())
+        {
+            
         }
         
         public EventingBasicConsumerNoLock(IModel model, SharedConcurrentQueue<BasicDeliverEventArgs> queue) : base(model)

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqPullingSubscriber.cs
@@ -191,7 +191,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
 
                 var queueName = _messageReadStrategy.Configure(settings, channel);
                 
-                var consumer = new QueueingBasicConsumerNoLock(channel);
+                var consumer = new EventingBasicConsumerNoLock(channel);
                 var tag = channel.BasicConsume(queueName, false, consumer);
 
                 while (!IsStopped())


### PR DESCRIPTION
Introducing `EventingBasicConsumerNoLock` to replace `QueueingBasicConsumer`.