### PR TITLE
feat(LT-5418): add connection auto naming feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2024-04-15)
+
+### Changed
+- LT-5418: Add connection auto naming to be visible in RabbitMQ dashboard
+
 ## 12.4.0 (2024-04-11)
 
 ### Changed

--- a/src/Lykke.RabbitMqBroker/AutorecoveringConnectionFactory.cs
+++ b/src/Lykke.RabbitMqBroker/AutorecoveringConnectionFactory.cs
@@ -11,7 +11,7 @@ namespace Lykke.RabbitMqBroker
     /// </summary>
     public sealed class AutorecoveringConnectionFactory : IAutorecoveringConnectionFactory
     {
-        public IAutorecoveringConnection Create(string connectionString, string name)
+        public IAutorecoveringConnection Create(string connectionString, string displayName)
         {
             var factory = new ConnectionFactory
             {
@@ -20,7 +20,7 @@ namespace Lykke.RabbitMqBroker
                 TopologyRecoveryEnabled = true,
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(60),
                 ContinuationTimeout = TimeSpan.FromSeconds(30),
-                ClientProvidedName = name
+                ClientProvidedName = displayName
             };
 
             return factory.CreateConnection() as IAutorecoveringConnection;

--- a/src/Lykke.RabbitMqBroker/ConnectionAssemblyBasedDisplayName.cs
+++ b/src/Lykke.RabbitMqBroker/ConnectionAssemblyBasedDisplayName.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+namespace Lykke.RabbitMqBroker;
+
+/// <summary>
+/// Display name of the connection based on the assembly metadata (title and version)
+/// </summary>
+internal abstract class ConnectionAssemblyBasedDisplayName
+{
+    private string _assemblyTitle;
+    private string _assemblyVersion;
+
+    protected ConnectionAssemblyBasedDisplayName()
+    {
+        ExtractAssemblyMetadata();
+    }
+        
+    private void ExtractAssemblyMetadata()
+    {
+        var assemblyName = Assembly.GetEntryAssembly()?.GetName();
+            
+        _assemblyTitle = assemblyName?.Name;
+        _assemblyVersion = assemblyName?.Version?.ToString();
+    }
+        
+    protected string BuildDisplayName(string prefix)
+    {
+        var result = prefix;
+        if (!string.IsNullOrWhiteSpace(_assemblyTitle))
+            result += $" from {_assemblyTitle}";
+        if (!string.IsNullOrWhiteSpace(_assemblyVersion))
+            result += $" of version {_assemblyVersion}";
+            
+        return result;
+    }
+}

--- a/src/Lykke.RabbitMqBroker/ConnectionProvider.cs
+++ b/src/Lykke.RabbitMqBroker/ConnectionProvider.cs
@@ -32,14 +32,14 @@ namespace Lykke.RabbitMqBroker
         public IAutorecoveringConnection GetOrCreateShared(string connectionString)
         {
             var hash = new ConnectionStringHash(connectionString);
-            return _sharedConnections.GetOrAdd(hash, _ => CreateConnection(connectionString, "SharedConnection"));
+            var displayName = new SharedConnectionAssemblyBasedDisplayName();
+            return _sharedConnections.GetOrAdd(hash, _ => CreateConnection(connectionString, displayName));
         }
 
         public IAutorecoveringConnection GetExclusive(string connectionString, string name = null)
         {
-            name ??= "ExclusiveConnection";
-            
-            var connection = CreateConnection(connectionString, name);
+            var displayName = new ExclusiveConnectionAssemblyBasedDisplayName(name);
+            var connection = CreateConnection(connectionString, displayName);
             _exclusiveConnections.Add(connection);
             return connection;
         }
@@ -59,9 +59,9 @@ namespace Lykke.RabbitMqBroker
             }
         }
         
-        private IAutorecoveringConnection CreateConnection(string connectionString, string name)
+        private IAutorecoveringConnection CreateConnection(string connectionString, string displayName)
         {
-            var connection = _connectionFactory.Create(connectionString, name);
+            var connection = _connectionFactory.Create(connectionString, displayName);
             AttachConnectionEventHandlers(connection);
             return connection;
         }

--- a/src/Lykke.RabbitMqBroker/ExclusiveConnectionAssemblyBasedDisplayName.cs
+++ b/src/Lykke.RabbitMqBroker/ExclusiveConnectionAssemblyBasedDisplayName.cs
@@ -1,0 +1,23 @@
+namespace Lykke.RabbitMqBroker;
+
+/// <summary>
+/// Display name for exclusive connection based on the assembly metadata.
+/// Can be customized with a custom name.
+/// </summary>
+internal sealed class ExclusiveConnectionAssemblyBasedDisplayName : ConnectionAssemblyBasedDisplayName
+{
+    private readonly string _value;
+        
+    public ExclusiveConnectionAssemblyBasedDisplayName(string customName = "")
+    {
+        var prefix = "Exclusive connection";
+        if (!string.IsNullOrWhiteSpace(customName))
+            prefix += $" {customName}";
+        _value = BuildDisplayName(prefix);
+    }
+        
+    public static implicit operator string(ExclusiveConnectionAssemblyBasedDisplayName displayName)
+    {
+        return displayName._value;
+    }
+}

--- a/src/Lykke.RabbitMqBroker/IAutorecoveringConnectionFactory.cs
+++ b/src/Lykke.RabbitMqBroker/IAutorecoveringConnectionFactory.cs
@@ -10,6 +10,6 @@ namespace Lykke.RabbitMqBroker
     /// </summary>
     public interface IAutorecoveringConnectionFactory
     {
-        public IAutorecoveringConnection Create(string connectionString, string name);
+        public IAutorecoveringConnection Create(string connectionString, string displayName);
     }
 }

--- a/src/Lykke.RabbitMqBroker/SharedConnectionAssemblyBasedDisplayName.cs
+++ b/src/Lykke.RabbitMqBroker/SharedConnectionAssemblyBasedDisplayName.cs
@@ -1,0 +1,19 @@
+namespace Lykke.RabbitMqBroker;
+
+/// <summary>
+/// Display name for shared connections based on the assembly metadata.
+/// </summary>
+internal sealed class SharedConnectionAssemblyBasedDisplayName : ConnectionAssemblyBasedDisplayName
+{
+    private readonly string _value;
+        
+    public SharedConnectionAssemblyBasedDisplayName()
+    {
+        _value = BuildDisplayName("Shared connection");
+    }
+        
+    public static implicit operator string(SharedConnectionAssemblyBasedDisplayName displayName)
+    {
+        return displayName._value;
+    }
+}

--- a/tests/Lykke.RabbitMqBroker.Tests/ConnectionDisplayNameTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/ConnectionDisplayNameTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace Lykke.RabbitMqBroker.Tests;
+
+[TestFixture]
+public class ConnectionDisplayNameTests
+{
+    [Test]
+    public void SharedConnection_DisplayName_Should_State_It_Is_Shared()
+    {
+        var displayName = new SharedConnectionAssemblyBasedDisplayName();
+
+        Assert.That((string)displayName, Does.Contain("Shared connection"));
+    }
+    
+    [Test]
+    public void ExclusiveConnection_DisplayName_Should_State_It_Is_Exclusive()
+    {
+        var displayName = new ExclusiveConnectionAssemblyBasedDisplayName();
+
+        Assert.That((string)displayName, Does.Contain("Exclusive connection"));
+    }
+    
+    [Test]
+    public void ExclusiveConnection_DisplayName_Should_Contain_Name_If_Provided()
+    {
+        var displayName = new ExclusiveConnectionAssemblyBasedDisplayName("MyConnection");
+
+        Assert.That((string)displayName, Does.Contain("MyConnection"));
+    }
+}

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeAutorecoveringConnectionFactory.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeAutorecoveringConnectionFactory.cs
@@ -7,7 +7,7 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
 {
     internal class FakeAutorecoveringConnectionFactory : IAutorecoveringConnectionFactory
     {
-        public IAutorecoveringConnection Create(string connectionString, string name)
+        public IAutorecoveringConnection Create(string connectionString, string displayName)
         {
             return new FakeConnection();
         }


### PR DESCRIPTION
Cosmetic changes, added a feature to auto name created connections based on connection type and entry assembly metadata (title and version).
Example of shared connection name: `Shared connection from Cronut of version 1.2.3`.
Example of exclusive connection name: `Exclusive connection MyConnection from Donut of version 1.2.3`.