### PR TITLE
Lt 5418 lykke rabbit mq broker update with new templates for subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2024-04-16)
+
+### Changed
+- LT-5418: Extend API to create subscribers
+
 ## 12.5.0 (2024-04-15)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [[tbd]] (2024-04-16)
 
-### Changed
+### Added
 - LT-5418: Extend API to create subscribers
 
 ## 12.5.0 (2024-04-15)

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriberConstructors.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriberConstructors.cs
@@ -1,0 +1,257 @@
+using System;
+using Lykke.RabbitMqBroker.Subscriber.Deserializers;
+using Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
+using Lykke.RabbitMqBroker.Subscriber.Middleware.ErrorHandling;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
+
+namespace Lykke.RabbitMqBroker.Subscriber
+{
+    public sealed partial class RabbitMqSubscriber<TTopicModel>
+    {
+        public static class MessagePack
+        {
+            /// <summary>
+            /// Create no loss message pack subscriber
+            /// </summary>
+            /// <param name="serviceProvider">Service collection provider</param>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateNoLossSubscriber(
+                IServiceProvider serviceProvider, 
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null)
+            {
+                return Create<NoLossMessageReadStrategy>(serviceProvider, settings, connection, configure);
+            }
+
+            /// <summary>
+            /// Create no loss message pack subscriber
+            /// </summary>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="loggerFactory">Logger factory</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateNoLossSubscriber(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+            {
+                return Create<NoLossMessageReadStrategy>(settings, connection, loggerFactory, configure);
+            }
+
+            /// <summary>
+            /// Create loss acceptable message pack subscriber
+            /// </summary>
+            /// <param name="serviceProvider">Service collection provider</param>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateLossAcceptableSubscriber(
+                IServiceProvider serviceProvider, 
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null)
+            {
+                return Create<LossAcceptableMessageReadStrategy>(serviceProvider, settings, connection, configure);
+            }
+
+            /// <summary>
+            /// Create loss acceptable message pack subscriber
+            /// </summary>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="loggerFactory">Logger factory</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateLossAcceptableSubscriber(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+            {
+                return Create<LossAcceptableMessageReadStrategy>(settings, connection, loggerFactory, configure);
+            }
+
+            private static RabbitMqSubscriber<TTopicModel> Create<TStrategy>(
+                IServiceProvider serviceProvider,
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null)
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger<RabbitMqSubscriber<TTopicModel>>();
+                var middlewareLogger = loggerFactory.CreateLogger<ExceptionSwallowMiddleware<TTopicModel>>();
+
+                var subscriber = CreateRawSubscriber<TStrategy>(settings, connection, logger, middlewareLogger);
+
+                configure?.Invoke(subscriber, serviceProvider);
+
+                return subscriber;
+            }
+
+            private static RabbitMqSubscriber<TTopicModel> Create<TStrategy>(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                var logger = loggerFactory.CreateLogger<RabbitMqSubscriber<TTopicModel>>();
+                var middlewareLogger = loggerFactory.CreateLogger<ExceptionSwallowMiddleware<TTopicModel>>();
+
+                var subscriber = CreateRawSubscriber<TStrategy>(settings, connection, logger, middlewareLogger);
+                
+                configure?.Invoke(subscriber);
+
+                return subscriber;
+            }
+
+            private static RabbitMqSubscriber<TTopicModel> CreateRawSubscriber<TStrategy>(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILogger<RabbitMqSubscriber<TTopicModel>> logger,
+                ILogger<ExceptionSwallowMiddleware<TTopicModel>> exceptionMiddlewareLogger)
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                return new RabbitMqSubscriber<TTopicModel>(
+                        logger,
+                        settings,
+                        connection)
+                    .SetMessageDeserializer(new MessagePackMessageDeserializer<TTopicModel>())
+                    .SetMessageReadStrategy(new TStrategy())
+                    .UseMiddleware(new ExceptionSwallowMiddleware<TTopicModel>(exceptionMiddlewareLogger));
+            }
+        }
+
+        public static class Json
+        {
+            /// <summary>
+            /// Create no loss json subscriber
+            /// </summary>
+            /// <param name="serviceProvider">Service collection provider</param>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateNoLossSubscriber(
+                IServiceProvider serviceProvider, 
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null)
+            {
+                return Create<NoLossMessageReadStrategy>(serviceProvider, settings, connection, configure);
+            }
+
+            /// <summary>
+            /// Create no loss json subscriber
+            /// </summary>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="loggerFactory">Logger factory</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateNoLossSubscriber(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+            {
+                return Create<NoLossMessageReadStrategy>(settings, connection, loggerFactory, configure);
+            }
+
+            /// <summary>
+            /// Create loss acceptable json subscriber
+            /// </summary>
+            /// <param name="serviceProvider">Service collection provider</param>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateLossAcceptableSubscriber(
+                IServiceProvider serviceProvider, 
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null)
+            {
+                return Create<LossAcceptableMessageReadStrategy>(serviceProvider, settings, connection, configure);
+            }
+
+            /// <summary>
+            /// Create loss acceptable json subscriber
+            /// </summary>
+            /// <param name="settings">Subscriber configuration</param>
+            /// <param name="connection">Autorecovering connection</param>
+            /// <param name="loggerFactory">Logger factory</param>
+            /// <param name="configure">Callback for additional configuration</param>
+            /// <returns></returns>
+            public static RabbitMqSubscriber<TTopicModel> CreateLossAcceptableSubscriber(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+            {
+                return Create<LossAcceptableMessageReadStrategy>(settings, connection, loggerFactory, configure);
+            }
+            
+            private static RabbitMqSubscriber<TTopicModel> Create<TStrategy>(
+                IServiceProvider serviceProvider,
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                Action<RabbitMqSubscriber<TTopicModel>, IServiceProvider> configure = null) 
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger<RabbitMqSubscriber<TTopicModel>>();
+                var middlewareLogger = loggerFactory.CreateLogger<ExceptionSwallowMiddleware<TTopicModel>>();
+
+                var subscriber = CreateRawSubscriber<TStrategy>(settings, connection, logger, middlewareLogger);
+
+                configure?.Invoke(subscriber, serviceProvider);
+
+                return subscriber;
+            }
+
+            private static RabbitMqSubscriber<TTopicModel> Create<TStrategy>(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILoggerFactory loggerFactory,
+                Action<RabbitMqSubscriber<TTopicModel>> configure = null)
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                var logger = loggerFactory.CreateLogger<RabbitMqSubscriber<TTopicModel>>();
+                var middlewareLogger = loggerFactory.CreateLogger<ExceptionSwallowMiddleware<TTopicModel>>();
+
+                var subscriber = CreateRawSubscriber<TStrategy>(settings, connection, logger, middlewareLogger);
+                
+                configure?.Invoke(subscriber);
+
+                return subscriber;
+            }
+
+            private static RabbitMqSubscriber<TTopicModel> CreateRawSubscriber<TStrategy>(
+                RabbitMqSubscriptionSettings settings,
+                IAutorecoveringConnection connection,
+                ILogger<RabbitMqSubscriber<TTopicModel>> logger,
+                ILogger<ExceptionSwallowMiddleware<TTopicModel>> exceptionMiddlewareLogger)
+                where TStrategy : IMessageReadStrategy, new()
+            {
+                return new RabbitMqSubscriber<TTopicModel>(
+                        logger,
+                        settings,
+                        connection)
+                    .SetMessageDeserializer(new JsonMessageDeserializer<TTopicModel>())
+                    .SetMessageReadStrategy(new TStrategy())
+                    .UseMiddleware(new ExceptionSwallowMiddleware<TTopicModel>(exceptionMiddlewareLogger));
+            }
+        }
+    }
+}

--- a/src/TestInvoke/Program.cs
+++ b/src/TestInvoke/Program.cs
@@ -29,7 +29,7 @@ namespace TestInvoke
                 NetworkRecoveryInterval = TimeSpan.FromSeconds(2)
             }.CreateConnection() as IAutorecoveringConnection;
 
-            HowToSubscribe.Example(rabbitMqSettings, connection);
+            HowToSubscribe.CustomSubscriber(rabbitMqSettings, connection);
             HowToSubscribe.Start();
 
             Console.WriteLine("Working... Press Enter to stop");

--- a/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
+++ b/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Lykke.RabbitMqBroker;
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.Middleware.ErrorHandling;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using RabbitMQ.Client;
 
@@ -15,7 +16,8 @@ namespace TestInvoke.SubscribeExample
     {
         private static RabbitMqSubscriber<string> _subscriber;
 
-        public static void Example(RabbitMqSubscriptionSettings settings, IAutorecoveringConnection connection)
+        #region Create custom suscriber
+        public static void CustomSubscriber(RabbitMqSubscriptionSettings settings, IAutorecoveringConnection connection)
         {
             _subscriber =
                 new RabbitMqSubscriber<string>(
@@ -28,6 +30,82 @@ namespace TestInvoke.SubscribeExample
                     .UseDefaultStrategy()
                     .Subscribe(HandleMessage);
         }
+        #endregion
+
+        #region Create subscriber manually with handy methods when no need to add to DI container
+        public static void Create_NoLoss_MessagePack_Subscriber(
+            RabbitMqSubscriptionSettings settings, 
+            IAutorecoveringConnection connection)
+        {
+            _subscriber = RabbitMqSubscriber<string>
+                .MessagePack
+                .CreateNoLossSubscriber(
+                    settings,
+                    connection,
+                    NullLoggerFactory.Instance)
+                .Subscribe(HandleMessage);
+        }
+
+        public static void Create_NoLoss_MessagePack_Subscriber_With_ServiceLocator(
+            IServiceProvider provider,
+            RabbitMqSubscriptionSettings settings,
+            IAutorecoveringConnection connection)
+        {
+            _subscriber = RabbitMqSubscriber<string>
+                .MessagePack
+                .CreateNoLossSubscriber(
+                    provider,
+                    settings,
+                    connection)
+                .Subscribe(HandleMessage);
+        }
+
+        public static void Create_LossAcceptable_Json_Subscriber(
+            RabbitMqSubscriptionSettings settings, 
+            IAutorecoveringConnection connection)
+        {
+            _subscriber = RabbitMqSubscriber<string>
+                .Json
+                .CreateLossAcceptableSubscriber(
+                    settings,
+                    connection,
+                    NullLoggerFactory.Instance)
+                .Subscribe(HandleMessage);
+        }
+        
+        public static void Create_LossAcceptable_Json_Subscriber_With_ServiceLocator(
+            IServiceProvider provider,
+            RabbitMqSubscriptionSettings settings, 
+            IAutorecoveringConnection connection)
+        {
+            _subscriber = RabbitMqSubscriber<string>
+                .Json
+                .CreateLossAcceptableSubscriber(
+                    provider,
+                    settings,
+                    connection)
+                .Subscribe(HandleMessage);
+        }
+        
+        #endregion
+
+        #region Create subcriber in semi-automatic mode and inject
+        public static void Inject_NoLoss_MessagePack_Subscriber_With_Shared_Connection_Auto_Resolve(
+            IServiceCollection services, 
+            RabbitMqSubscriptionSettings settings)
+        {
+            services.AddMessagePackNoLossSubscriber<string>(settings, HandleMessage);
+        }
+        
+        public static void Inject_NoLoss_MessagePack_Subscriber_With_Custom_Connection(
+            IServiceCollection services, 
+            RabbitMqSubscriptionSettings settings,
+            IAutorecoveringConnection connection)
+        {
+            services.AddMessagePackNoLossSubscriber<string>(settings, connection, HandleMessage);
+        }
+        
+        #endregion
         
         public static void Start()
         {


### PR DESCRIPTION
The changes implemented extend the subscriber creation API landscape and add convenient methods to create subscriber not only with registration in DI container but also as a separate instance when no DI registration is required.
Also extended usage examples.