### PR TITLE
feat(LT-5418): add listener concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2024-04-22)
+
+### Added
+- LT-5418: Listener concept introduced
+
 ## 12.6.0 (2024-04-16)
 
 ### Added

--- a/Lykke.RabbitMqBroker.sln
+++ b/Lykke.RabbitMqBroker.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lykke.RabbitMqBroker", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogParser", "src\LogParser\LogParser.csproj", "{573D97AA-1325-4CD9-BF47-951292C5C2E8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestDIApp", "src\TestDIApp\TestDIApp.csproj", "{52B1596B-5B07-462A-BFB1-174424B5AD75}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{573D97AA-1325-4CD9-BF47-951292C5C2E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{573D97AA-1325-4CD9-BF47-951292C5C2E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{573D97AA-1325-4CD9-BF47-951292C5C2E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52B1596B-5B07-462A-BFB1-174424B5AD75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52B1596B-5B07-462A-BFB1-174424B5AD75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52B1596B-5B07-462A-BFB1-174424B5AD75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52B1596B-5B07-462A-BFB1-174424B5AD75}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,6 +54,7 @@ Global
 		{FC96342D-3EA6-44D2-A62C-06019661FC54} = {7DA224A2-9CA2-44A8-9D8C-53C8BCF2580A}
 		{064E44E7-1F1D-41C7-AA2B-21D9A528B30C} = {CC53CCE3-238A-43B8-B1C1-49068E4CFF87}
 		{573D97AA-1325-4CD9-BF47-951292C5C2E8} = {CC53CCE3-238A-43B8-B1C1-49068E4CFF87}
+		{52B1596B-5B07-462A-BFB1-174424B5AD75} = {CC53CCE3-238A-43B8-B1C1-49068E4CFF87}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {050A064F-4C1E-4C94-88FF-5DD3BD0AAABA}

--- a/src/Lykke.RabbitMqBroker/ListenerDependencyInjectionExtensions.cs
+++ b/src/Lykke.RabbitMqBroker/ListenerDependencyInjectionExtensions.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Autofac;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Lykke.RabbitMqBroker
+{
+    public static class ListenerDependencyInjectionExtensions
+    {
+        /// <summary>
+        /// Registers a Rabbit MQ listener in the DI container.
+        /// Behind the scenes, it registers a low-level subscriber or
+        /// multiple subscribers, a message handler and options for the listener.
+        ///
+        /// Listener starts subscriber(-s) automatically when the application starts.
+        /// For this Autofac is required to be used at least as service provider factory.
+        /// Otherwise, listener should be started manually by resolving it
+        /// from the container as <see cref="IStartable"/>.
+        ///
+        /// Implements <see cref="IDisposable"/> interface so that container can
+        /// take care of disposing the listener when the application stops.
+        ///
+        /// Can be registered once for each message type. If required, handling
+        /// can be extended by registering more handlers implementing
+        /// <see cref="IMessageHandler{TModel}"/> interface.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="subscriptionSettings"></param>
+        /// <param name="setupListenerOptions"></param>
+        /// <param name="configureSubscriber"></param>
+        /// <typeparam name="TModel"></typeparam>
+        /// <typeparam name="THandler"></typeparam>
+        /// <returns></returns>
+        public static IServiceCollection AddRabbitMqListener<TModel, THandler>(
+            this IServiceCollection services,
+            RabbitMqSubscriptionSettings subscriptionSettings,
+            Action<RabbitMqListenerOptions<TModel>> setupListenerOptions,
+            Action<RabbitMqSubscriber<TModel>> configureSubscriber = null) 
+            where TModel : class
+            where THandler : class, IMessageHandler<TModel>
+        {
+            services.AddSingleton<IMessageHandler<TModel>, THandler>();
+            
+            services.AddSingleton(p => new RabbitMqListener<TModel>(
+                p.GetRequiredService<IConnectionProvider>(),
+                subscriptionSettings,
+                p.GetRequiredService<IOptions<RabbitMqListenerOptions<TModel>>>(),
+                configureSubscriber,
+                p.GetRequiredService<IEnumerable<IMessageHandler<TModel>>>(),
+                p.GetRequiredService<ILoggerFactory>()));
+
+            services.AddSingleton<IStartable>(p => p.GetService<RabbitMqListener<TModel>>());
+            
+            services.Configure(setupListenerOptions);
+            
+            return services;
+        }
+    }
+}

--- a/src/Lykke.RabbitMqBroker/ListenerDependencyInjectionExtensions.cs
+++ b/src/Lykke.RabbitMqBroker/ListenerDependencyInjectionExtensions.cs
@@ -31,9 +31,9 @@ namespace Lykke.RabbitMqBroker
         /// <see cref="IMessageHandler{TModel}"/> interface.
         /// </summary>
         /// <param name="services"></param>
-        /// <param name="subscriptionSettings"></param>
-        /// <param name="setupListenerOptions"></param>
-        /// <param name="configureSubscriber"></param>
+        /// <param name="subscriptionSettings">RabbitMQ host connection settings</param> 
+        /// <param name="setupListenerOptions">Options which are more business specific than technical</param>
+        /// <param name="configureSubscriber">Low-level subscriber configuration callback</param>
         /// <typeparam name="TModel"></typeparam>
         /// <typeparam name="THandler"></typeparam>
         /// <returns></returns>

--- a/src/Lykke.RabbitMqBroker/SerializationFormat.cs
+++ b/src/Lykke.RabbitMqBroker/SerializationFormat.cs
@@ -1,4 +1,4 @@
-﻿namespace Lykke.RabbitMqBroker.Logging
+﻿namespace Lykke.RabbitMqBroker
 {
     public enum SerializationFormat
     {

--- a/src/Lykke.RabbitMqBroker/Subscriber/IMessageHandler.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/IMessageHandler.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Lykke.RabbitMqBroker.Subscriber
+{
+    public interface IMessageHandler<in T>
+    {
+        public Task Handle(T message);
+    }
+}

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListener.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListener.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Autofac;
 using JetBrains.Annotations;
@@ -124,12 +125,10 @@ namespace Lykke.RabbitMqBroker.Subscriber
             };
         }
 
-        private async Task Handle(T message)
+        private Task Handle(T message)
         {
-            foreach (var handler in _handlers)
-            {
-                await handler.Handle(message);
-            }
+            var allTasks = _handlers.Select(h => h.Handle(message));
+            return Task.WhenAll(allTasks);
         }
 
         void IDisposable.Dispose()

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListenerOptions.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListenerOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace Lykke.RabbitMqBroker.Subscriber
+{
+    public class RabbitMqListenerOptions<T> where T : class
+    {
+        public bool ShareConnection { get; set; } = true;
+        public SerializationFormat SerializationFormat { get; set; } = SerializationFormat.Json;
+        public SubscriptionTemplate SubscriptionTemplate { get; set; } = SubscriptionTemplate.NoLoss;
+        public byte ConsumerCount { get; set; } = 1;
+        public static RabbitMqListenerOptions<T> Default => new();
+        public bool ReadCorrelationId { get; set; } = false;
+    }
+}

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListenerOptions.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqListenerOptions.cs
@@ -9,7 +9,8 @@ namespace Lykke.RabbitMqBroker.Subscriber
         public SerializationFormat SerializationFormat { get; set; } = SerializationFormat.Json;
         public SubscriptionTemplate SubscriptionTemplate { get; set; } = SubscriptionTemplate.NoLoss;
         public byte ConsumerCount { get; set; } = 1;
-        public static RabbitMqListenerOptions<T> Default => new();
         public bool ReadCorrelationId { get; set; } = false;
+        
+        public static RabbitMqListenerOptions<T> Default => new();
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/SubscriptionTemplate.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/SubscriptionTemplate.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace Lykke.RabbitMqBroker.Subscriber
+{
+    public enum SubscriptionTemplate
+    {
+        None,
+        NoLoss,
+        LossAcceptable
+    }
+}

--- a/src/Lykke.RabbitMqBroker/SubscriberDependencyInjectionExtensions.cs
+++ b/src/Lykke.RabbitMqBroker/SubscriberDependencyInjectionExtensions.cs
@@ -9,10 +9,11 @@ using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker
 {
-    public static class DependencyInjectionExtensions
+    public static class SubscriberDependencyInjectionExtensions
     {
         /// <summary>
         /// Adds a JSON subscriber to the service collection with no loss guarantee.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -31,17 +32,18 @@ namespace Lykke.RabbitMqBroker
                 var subscriber = RabbitMqSubscriber<T>
                     .Json
                     .CreateNoLossSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a JSON subscriber to the service collection with no loss guarantee.
         /// Uses shared connection.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -57,20 +59,21 @@ namespace Lykke.RabbitMqBroker
             {
                 var connectionProvider = p.GetRequiredService<IConnectionProvider>();
                 var connection = connectionProvider.GetOrCreateShared(settings.ConnectionString);
-                
+
                 var subscriber = RabbitMqSubscriber<T>
                     .Json
                     .CreateNoLossSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a JSON subscriber to the service collection with loss acceptable guarantee.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -89,17 +92,18 @@ namespace Lykke.RabbitMqBroker
                 var subscriber = RabbitMqSubscriber<T>
                     .Json
                     .CreateLossAcceptableSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a JSON subscriber to the service collection with loss acceptable guarantee.
         /// Uses shared connection.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -115,20 +119,21 @@ namespace Lykke.RabbitMqBroker
             {
                 var connectionProvider = p.GetRequiredService<IConnectionProvider>();
                 var connection = connectionProvider.GetOrCreateShared(settings.ConnectionString);
-                
+
                 var subscriber = RabbitMqSubscriber<T>
                     .Json
                     .CreateLossAcceptableSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a MessagePack subscriber to the service collection with no loss guarantee.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -147,17 +152,18 @@ namespace Lykke.RabbitMqBroker
                 var subscriber = RabbitMqSubscriber<T>
                     .MessagePack
                     .CreateNoLossSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a MessagePack subscriber to the service collection with no loss guarantee.
         /// Uses shared connection.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -173,20 +179,21 @@ namespace Lykke.RabbitMqBroker
             {
                 var connectionProvider = p.GetRequiredService<IConnectionProvider>();
                 var connection = connectionProvider.GetOrCreateShared(settings.ConnectionString);
-                
+
                 var subscriber = RabbitMqSubscriber<T>
                     .MessagePack
                     .CreateNoLossSubscriber(p, settings, connection, configure);
-                
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a MessagePack subscriber to the service collection with loss acceptable guarantee.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -205,17 +212,18 @@ namespace Lykke.RabbitMqBroker
                 var subscriber = RabbitMqSubscriber<T>
                     .MessagePack
                     .CreateLossAcceptableSubscriber(p, settings, connection, configure);
-                    
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }
-        
+
         /// <summary>
         /// Adds a MessagePack subscriber to the service collection with loss acceptable guarantee.
         /// Uses shared connection.
+        /// Resolve <see cref="RabbitMqSubscriber{T}"/> to get the instance.
         /// </summary>
         /// <param name="services"></param>
         /// <param name="settings"></param>
@@ -231,14 +239,14 @@ namespace Lykke.RabbitMqBroker
             {
                 var connectionProvider = p.GetRequiredService<IConnectionProvider>();
                 var connection = connectionProvider.GetOrCreateShared(settings.ConnectionString);
-                
+
                 var subscriber = RabbitMqSubscriber<T>
                     .MessagePack
                     .CreateLossAcceptableSubscriber(p, settings, connection, configure);
-                    
+
                 if (handler != null)
                     subscriber.Subscribe(handler);
-                
+
                 return subscriber;
             });
         }

--- a/src/TestDIApp/Handlers/AnotherJupiterMessageHandler.cs
+++ b/src/TestDIApp/Handlers/AnotherJupiterMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Messages;
+
+namespace TestDIApp.Handlers;
+
+public class AnotherJupiterMessageHandler : IMessageHandler<JupiterMessage>
+{
+    private readonly ILogger<AnotherJupiterMessageHandler> _logger;
+
+    public AnotherJupiterMessageHandler(ILogger<AnotherJupiterMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(JupiterMessage jupiterMessage)
+    {
+        var messageJson = JsonSerializer.Serialize(jupiterMessage);
+        _logger.LogInformation("Received message: {message}", messageJson);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestDIApp/Handlers/JupiterMessageHandler.cs
+++ b/src/TestDIApp/Handlers/JupiterMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Messages;
+
+namespace TestDIApp.Handlers;
+
+public class JupiterMessageHandler : IMessageHandler<JupiterMessage>
+{
+    private readonly ILogger<JupiterMessageHandler> _logger;
+
+    public JupiterMessageHandler(ILogger<JupiterMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(JupiterMessage jupiterMessage)
+    {
+        var messageJson = JsonSerializer.Serialize(jupiterMessage);
+        _logger.LogInformation("Received message: {message}", messageJson);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestDIApp/Handlers/MarsMessageHandler.cs
+++ b/src/TestDIApp/Handlers/MarsMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Messages;
+
+namespace TestDIApp.Handlers;
+
+public class MarsMessageHandler : IMessageHandler<MarsMessage>
+{
+    private readonly ILogger<MarsMessageHandler> _logger;
+
+    public MarsMessageHandler(ILogger<MarsMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(MarsMessage marsMessage)
+    {
+        var messageJson = JsonSerializer.Serialize(marsMessage);
+        _logger.LogInformation("Received message: {message}", messageJson);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestDIApp/Handlers/MercuryMessageHandler.cs
+++ b/src/TestDIApp/Handlers/MercuryMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Messages;
+
+namespace TestDIApp.Handlers;
+
+public class MercuryMessageHandler : IMessageHandler<MercuryMessage>
+{
+    private readonly ILogger<MercuryMessageHandler> _logger;
+
+    public MercuryMessageHandler(ILogger<MercuryMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(MercuryMessage message)
+    {
+        var messageJson = JsonSerializer.Serialize(message);
+        _logger.LogInformation("Received message: {message}", messageJson);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestDIApp/Handlers/VenusMessageHandler.cs
+++ b/src/TestDIApp/Handlers/VenusMessageHandler.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Messages;
+
+namespace TestDIApp.Handlers;
+
+public class VenusMessageHandler : IMessageHandler<VenusMessage>
+{
+    private readonly ILogger<VenusMessageHandler> _logger;
+
+    public VenusMessageHandler(ILogger<VenusMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task Handle(VenusMessage message)
+    {
+        var messageJson = JsonSerializer.Serialize(message);
+        _logger.LogInformation("Received message: {message}", messageJson);
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/TestDIApp/Messages/JupiterMessage.cs
+++ b/src/TestDIApp/Messages/JupiterMessage.cs
@@ -1,0 +1,10 @@
+using JetBrains.Annotations;
+
+namespace TestDIApp.Messages;
+
+[UsedImplicitly]
+public class JupiterMessage
+{
+    public string Sender { get; set; } = "Someone on Jupiter";
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/TestDIApp/Messages/MarsMessage.cs
+++ b/src/TestDIApp/Messages/MarsMessage.cs
@@ -1,0 +1,10 @@
+using JetBrains.Annotations;
+
+namespace TestDIApp.Messages;
+
+[UsedImplicitly]
+public class MarsMessage
+{
+    public string Sender { get; set; } = "Someone on Mars";
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/TestDIApp/Messages/MercuryMessage.cs
+++ b/src/TestDIApp/Messages/MercuryMessage.cs
@@ -1,0 +1,10 @@
+using JetBrains.Annotations;
+
+namespace TestDIApp.Messages;
+
+[UsedImplicitly]
+public class MercuryMessage
+{
+    public string Sender { get; set; } = "Someone on Mercury";
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/TestDIApp/Messages/VenusMessage.cs
+++ b/src/TestDIApp/Messages/VenusMessage.cs
@@ -1,0 +1,10 @@
+using JetBrains.Annotations;
+
+namespace TestDIApp.Messages;
+
+[UsedImplicitly]
+public class VenusMessage
+{
+    public string Sender { get; set; } = "Someone on Venus";
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/TestDIApp/Program.cs
+++ b/src/TestDIApp/Program.cs
@@ -1,0 +1,80 @@
+﻿using Autofac.Extensions.DependencyInjection;
+using Lykke.RabbitMqBroker;
+using Lykke.RabbitMqBroker.Subscriber;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TestDIApp.Handlers;
+using TestDIApp.Messages;
+
+var builder = Host.CreateDefaultBuilder(args);
+
+await builder
+    .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+    .ConfigureAppConfiguration((_, configurationBuilder) =>
+    {
+        configurationBuilder.AddEnvironmentVariables();
+        configurationBuilder.AddJsonFile("appsettings.json");
+    })
+    .ConfigureServices((ctx, services) =>
+    {
+        services.AddLogging(loggingBuilder => loggingBuilder.AddConsole());
+        services.AddRabbitMqConnectionProvider();
+        
+        // Add Mars messages listener
+        var marsSubscriptionSettings = ctx
+            .Configuration
+            .GetSection("MarsSubscription")
+            .Get<RabbitMqSubscriptionSettings>();
+        services.AddRabbitMqListener<MarsMessage, MarsMessageHandler>(
+            marsSubscriptionSettings,
+            opt =>
+            {
+                opt.SerializationFormat = SerializationFormat.Json;
+                opt.ShareConnection = true;
+                opt.SubscriptionTemplate = SubscriptionTemplate.NoLoss;
+            });
+
+        // Add Jupiter messages listener
+        var jupiterSubscriptionSettings = ctx
+            .Configuration
+            .GetSection("JupiterSubscription")
+            .Get<RabbitMqSubscriptionSettings>();
+        services.AddRabbitMqListener<JupiterMessage, JupiterMessageHandler>(
+            jupiterSubscriptionSettings,
+            opt =>
+            {
+                opt.SerializationFormat = SerializationFormat.Json;
+                opt.ShareConnection = true;
+                opt.SubscriptionTemplate = SubscriptionTemplate.LossAcceptable;
+            });
+        
+        // Additional Jupiter messages handler
+        services.AddSingleton<IMessageHandler<JupiterMessage>, AnotherJupiterMessageHandler>();
+        
+        // empty options, defaults will be used
+        var venusSubscriptionSettings = ctx
+            .Configuration
+            .GetSection("VenusSubscription")
+            .Get<RabbitMqSubscriptionSettings>();
+        services.AddRabbitMqListener<VenusMessage, VenusMessageHandler>(
+            venusSubscriptionSettings, _ => { });
+
+        // subscriber additional manual re-configuration example
+        var mercurySubscriptionSettings = ctx
+            .Configuration
+            .GetSection("MercurySubscription")
+            .Get<RabbitMqSubscriptionSettings>();
+        services.AddRabbitMqListener<MercuryMessage, MercuryMessageHandler>(
+            mercurySubscriptionSettings,
+            _ => { },
+            s => 
+                s.SetPrefetchCount(100)
+                    //.UseMiddleware()
+                    //.SetReadHeadersAction())
+                    // ...
+                    );
+
+    })
+    .RunConsoleAsync();

--- a/src/TestDIApp/TestDIApp.csproj
+++ b/src/TestDIApp/TestDIApp.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Lykke.RabbitMqBroker\Lykke.RabbitMqBroker.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
+</Project>

--- a/src/TestDIApp/appsettings-template.json
+++ b/src/TestDIApp/appsettings-template.json
@@ -1,0 +1,22 @@
+{
+  "JupiterSubscription": {
+    "ConnectionString": "",
+    "ExchangeName": "jupiter",
+    "QueueName": "queue-jupiter"
+  },
+  "MarsSubscription": {
+    "ConnectionString": "",
+    "ExchangeName": "mars",
+    "QueueName": "queue-mars"
+  },
+  "VenusSubscription": {
+    "ConnectionString": "",
+    "ExchangeName": "venus",
+    "QueueName": "queue-venus"
+  },
+  "MercurySubscription": {
+    "ConnectionString": "",
+    "ExchangeName": "mercury",
+    "QueueName": "queue-mercury"
+  }
+}

--- a/src/TestInvoke/PublishExample/TestMessageSerializer.cs
+++ b/src/TestInvoke/PublishExample/TestMessageSerializer.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
-using Lykke.RabbitMqBroker.Logging;
+using Lykke.RabbitMqBroker;
 using Lykke.RabbitMqBroker.Publisher.Serializers;
 
 namespace TestInvoke.PublishExample


### PR DESCRIPTION
Introducing Listener concept to hide the peculiarities of creating low-level subscriber, starting and disposing it allowing to concentrate on business logic implementation. Provides configuration options where:

1. subscriber can be configured in terms of templates (no loss, loss acceptable)
2. subscriber can be configured granularly if required.

Usage examples added.