### PR TITLE
Lt 5705 rabbit mq broker add quorum queues support for nl queues

### DIFF
--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/IMessageReadStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/IMessageReadStrategy.cs
@@ -16,21 +16,8 @@ namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
         /// Configures the queue
         /// </summary>
         /// <param name="settings"></param>
-        /// <param name="channel"></param>
-        /// <returns> The name of the queue </returns>
-        [Obsolete("Use Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory) instead")]
-        string Configure(RabbitMqSubscriptionSettings settings, IModel channel);
-
-        /// <summary>
-        /// Configures the queue
-        /// </summary>
-        /// <param name="settings"></param>
         /// <param name="channelFactory"></param>
         /// <returns> The name of the queue </returns>
-        string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory)
-        {
-            using var channel = channelFactory();
-            return Configure(settings, channel);
-        }
+        string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory);
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/IMessageReadStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/IMessageReadStrategy.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
+
 using JetBrains.Annotations;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
@@ -10,13 +13,24 @@ namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
     public interface IMessageReadStrategy
     {
         /// <summary>
-        /// Configures the channel for the message reading
+        /// Configures the queue
         /// </summary>
         /// <param name="settings"></param>
         /// <param name="channel"></param>
-        /// <returns>
-        /// The name of the queue that was created
-        /// </returns>
+        /// <returns> The name of the queue </returns>
+        [Obsolete("Use Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory) instead")]
         string Configure(RabbitMqSubscriptionSettings settings, IModel channel);
+
+        /// <summary>
+        /// Configures the queue
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="channelFactory"></param>
+        /// <returns> The name of the queue </returns>
+        string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory)
+        {
+            using var channel = channelFactory();
+            return Configure(settings, channel);
+        }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/MessageReadQueueStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/MessageReadQueueStrategy.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
 {
     public class MessageReadQueueStrategy : IMessageReadStrategy
     {
-        public string Configure(RabbitMqSubscriptionSettings settings, IModel channel)
+        public string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory)
         {
             return settings.QueueName;
         }

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/MessageReadWithTemporaryQueueStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/MessageReadWithTemporaryQueueStrategy.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
@@ -15,12 +17,14 @@ namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies
             _routingKey = routingKey ?? string.Empty;
         }
 
-        public string Configure(RabbitMqSubscriptionSettings settings, IModel channel)
+        public string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory)
         {
+            using var channel = channelFactory();
+
             var queueName = settings.GetQueueName();
             var autodelete = !settings.IsDurable;
             IDictionary<string, object> args = null;
-            
+
             if (!string.IsNullOrEmpty(settings.DeadLetterExchangeName))
             {
                 var poisonQueueName = settings.GetPoisonQueueName();

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/QueueConfigurator.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/QueueConfigurator.cs
@@ -1,3 +1,5 @@
+using System;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
@@ -5,9 +7,11 @@ namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
 internal static class QueueConfigurator
 {
     public static QueueConfigurationResult Configure(
-        IModel channel,
+        Func<IModel> channelFactory,
         QueueConfigurationOptions options)
     {
+        using var channel = channelFactory();
+
         var argumentsBuilder = new QueueDeclarationArgumentsBuilder();
         if (options.ShouldConfigureDeadLettering())
         {

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/TemplatedMessageReadStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/TemplatedMessageReadStrategy.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2024 Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
@@ -20,10 +22,10 @@ public abstract class TemplatedMessageReadStrategy : IMessageReadStrategy
         _routingKey = routingKey ?? string.Empty;
     }
 
-    public string Configure(RabbitMqSubscriptionSettings settings, IModel channel)
+    public string Configure(RabbitMqSubscriptionSettings settings, Func<IModel> channelFactory)
     {
         var queueConfigurationResult = QueueConfigurator.Configure(
-            channel,
+            channelFactory,
             CreateQueueConfigurationOptions(settings));
 
         return queueConfigurationResult.QueueName;

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
@@ -183,7 +183,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
         {
             _cancellationTokenSource?.Cancel();
 
-            if (_consumer.IsRunning)
+            if (_consumer?.IsRunning ?? false)
             {
                 _channel.BasicCancel(_consumerTag);
                 _consumer.Received -= OnReceived;

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
@@ -168,11 +168,11 @@ namespace Lykke.RabbitMqBroker.Subscriber
                 : new ActualHandlerMiddleware<TTopicModel>(CancellableEventHandler);
             _middlewareQueue.AddMiddleware(actualHandlerMiddleware);
 
-            _channel = GetOrCreateChannel();
+            _channel = GetOrCreateConsumerChannel();
 
             _consumer = GetOrCreateConsumer(_channel);
 
-            var queueName = MessageReadStrategy.Configure(_settings, _channel);
+            var queueName = MessageReadStrategy.Configure(_settings, CreateConfiguratorChannel);
 
             _consumerTag = _channel.BasicConsume(queueName, false, _consumer);
 
@@ -216,7 +216,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
                 throw new InvalidOperationException("Please, specify message handler");
         }
 
-        private IModel GetOrCreateChannel()
+        private IModel GetOrCreateConsumerChannel()
         {
             if (_channel != null)
                 return _channel;
@@ -227,6 +227,11 @@ namespace Lykke.RabbitMqBroker.Subscriber
                 _channel.BasicQos(0, _prefetchCount.Value, false);
 
             return _channel;
+        }
+
+        private IModel CreateConfiguratorChannel()
+        {
+            return _connection.CreateModel();
         }
 
         private EventingBasicConsumer GetOrCreateConsumer(IModel channel)

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeChannel.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeChannel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -88,12 +89,10 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
 
         public void Close()
         {
-            throw new NotImplementedException();
         }
 
         public void Close(ushort replyCode, string replyText)
         {
-            throw new NotImplementedException();
         }
 
         public void ConfirmSelect()
@@ -263,7 +262,7 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
         public event EventHandler<CallbackExceptionEventArgs> CallbackException;
         public event EventHandler<FlowControlEventArgs> FlowControl;
         public event EventHandler<ShutdownEventArgs> ModelShutdown;
-        
+
         public ushort PrefetchCount { get; private set; }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeChannel.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeChannel.cs
@@ -262,7 +262,6 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
         public event EventHandler<CallbackExceptionEventArgs> CallbackException;
         public event EventHandler<FlowControlEventArgs> FlowControl;
         public event EventHandler<ShutdownEventArgs> ModelShutdown;
-
         public ushort PrefetchCount { get; private set; }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeConnection.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeConnection.cs
@@ -8,6 +8,7 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
 {
     internal class FakeConnection : IAutorecoveringConnection
     {
+        public List<FakeChannel> Channels { get; } = [];
         public int LocalPort { get; }
         public int RemotePort { get; }
         public void Dispose()
@@ -57,16 +58,9 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
 
         public IModel CreateModel()
         {
-            // Consumer channel is the one requested first by subscriber
-            // so we have to capture only first call.
-            // Subsequent calls can happen to request separate configuration channels.
-            if (ConsumerChannel == null)
-            {
-                ConsumerChannel = new FakeChannel();
-                return ConsumerChannel;
-            }
-
-            return new FakeChannel();
+            var channel = new FakeChannel();
+            Channels.Add(channel);
+            return channel;
         }
 
         public void HandleConnectionBlocked(string reason)
@@ -99,7 +93,5 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
         public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
         public event EventHandler<ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
         public event EventHandler<QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
-
-        public FakeChannel ConsumerChannel { get; private set; }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeConnection.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/FakeConnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -40,28 +41,32 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
 
         public void Close()
         {
-            throw new NotImplementedException();
         }
 
         public void Close(ushort reasonCode, string reasonText)
         {
-            throw new NotImplementedException();
         }
 
         public void Close(TimeSpan timeout)
         {
-            throw new NotImplementedException();
         }
 
         public void Close(ushort reasonCode, string reasonText, TimeSpan timeout)
         {
-            throw new NotImplementedException();
         }
 
         public IModel CreateModel()
         {
-            LatestChannel = new FakeChannel();
-            return LatestChannel;
+            // Consumer channel is the one requested first by subscriber
+            // so we have to capture only first call.
+            // Subsequent calls can happen to request separate configuration channels.
+            if (ConsumerChannel == null)
+            {
+                ConsumerChannel = new FakeChannel();
+                return ConsumerChannel;
+            }
+
+            return new FakeChannel();
         }
 
         public void HandleConnectionBlocked(string reason)
@@ -94,7 +99,7 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes
         public event EventHandler<ConnectionRecoveryErrorEventArgs> ConnectionRecoveryError;
         public event EventHandler<ConsumerTagChangedAfterRecoveryEventArgs> ConsumerTagChangeAfterRecovery;
         public event EventHandler<QueueNameChangedAfterRecoveryEventArgs> QueueNameChangeAfterRecovery;
-        
-        public FakeChannel LatestChannel { get; private set; }
+
+        public FakeChannel ConsumerChannel { get; private set; }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/Fakes/QueueConfiguratorFakeChannel.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Fakes/QueueConfiguratorFakeChannel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -7,14 +8,21 @@ namespace Lykke.RabbitMqBroker.Tests.Fakes;
 
 public class QueueConfiguratorFakeChannel : IModel
 {
-    private readonly HashSet<string> _declaredQueues = new();
-    private readonly HashSet<string> _declaredExchanges = new();
-    private readonly HashSet<string> _boundQueues = new();
-    private readonly Dictionary<string, IDictionary<string, object>> _declaredQueuesArguments = new();
-    
+    public static HashSet<string> DeclaredQueues { get; } = [];
+    public static HashSet<string> DeclaredExchanges { get; } = [];
+    public static HashSet<string> BoundQueues { get; } = [];
+    public static Dictionary<string, IDictionary<string, object>> DeclaredQueuesArguments { get; } = [];
+
+    public static void ResetCounters()
+    {
+        DeclaredQueues.Clear();
+        DeclaredExchanges.Clear();
+        BoundQueues.Clear();
+        DeclaredQueuesArguments.Clear();
+    }
+
     public void Dispose()
     {
-        throw new NotImplementedException();
     }
 
     public void Abort()
@@ -129,17 +137,17 @@ public class QueueConfiguratorFakeChannel : IModel
 
     public void ExchangeDeclare(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
     {
-        _declaredExchanges.Add(exchange);
+        DeclaredExchanges.Add(exchange);
     }
 
     public void ExchangeDeclareNoWait(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments)
     {
-        _declaredExchanges.Add(exchange);
+        DeclaredExchanges.Add(exchange);
     }
 
     public void ExchangeDeclarePassive(string exchange)
     {
-        _declaredExchanges.Add(exchange);
+        DeclaredExchanges.Add(exchange);
     }
 
     public void ExchangeDelete(string exchange, bool ifUnused)
@@ -164,30 +172,30 @@ public class QueueConfiguratorFakeChannel : IModel
 
     public void QueueBind(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
     {
-        _boundQueues.Add(queue);
+        BoundQueues.Add(queue);
     }
 
     public void QueueBindNoWait(string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
     {
-        _boundQueues.Add(queue);
+        BoundQueues.Add(queue);
     }
 
     public QueueDeclareOk QueueDeclare(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
     {
-        _declaredQueues.Add(queue);
-        _declaredQueuesArguments.Add(queue, arguments);
+        DeclaredQueues.Add(queue);
+        DeclaredQueuesArguments.Add(queue, arguments);
         return new QueueDeclareOk(queue, 0, 0);
     }
 
     public void QueueDeclareNoWait(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments)
     {
-        _declaredQueues.Add(queue);
-        _declaredQueuesArguments.Add(queue, arguments);
+        DeclaredQueues.Add(queue);
+        DeclaredQueuesArguments.Add(queue, arguments);
     }
 
     public QueueDeclareOk QueueDeclarePassive(string queue)
     {
-        _declaredQueues.Add(queue);
+        DeclaredQueues.Add(queue);
         return new QueueDeclareOk(queue, 0, 0);
     }
 
@@ -275,9 +283,4 @@ public class QueueConfiguratorFakeChannel : IModel
     public event EventHandler<CallbackExceptionEventArgs> CallbackException;
     public event EventHandler<FlowControlEventArgs> FlowControl;
     public event EventHandler<ShutdownEventArgs> ModelShutdown;
-
-    public IReadOnlyCollection<string> DeclaredQueues => _declaredQueues;
-    public IReadOnlyCollection<string> DeclaredExchanges => _declaredExchanges;
-    public IReadOnlyCollection<string> BoundQueues => _boundQueues;
-    public IReadOnlyDictionary<string, IDictionary<string, object>> DeclaredQueuesArguments => _declaredQueuesArguments;
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/QueueConfiguratorTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/QueueConfiguratorTests.cs
@@ -1,5 +1,3 @@
-using System.Runtime;
-
 using Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
 using Lykke.RabbitMqBroker.Tests.Fakes;
 
@@ -19,12 +17,11 @@ public class QueueConfiguratorTests
             QueueName = "q"
         };
 
-        var channel = new QueueConfiguratorFakeChannel();
-        var result = QueueConfigurator.Configure(channel, options);
+        var result = QueueConfigurator.Configure(() => new QueueConfiguratorFakeChannel(), options);
 
         Assert.That(options.QueueName, Is.EqualTo(result.QueueName));
-        Assert.That(channel.DeclaredExchanges, Does.Not.Contain(options.ExchangeName));
-        Assert.That(channel.DeclaredQueues, Does.Contain(options.QueueName));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredExchanges, Does.Not.Contain(options.ExchangeName));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredQueues, Does.Contain(options.QueueName));
     }
 
     [Test]
@@ -37,11 +34,10 @@ public class QueueConfiguratorTests
             QueueName = "q"
         };
 
-        var channel = new QueueConfiguratorFakeChannel();
-        QueueConfigurator.Configure(channel, options);
+        QueueConfigurator.Configure(() => new QueueConfiguratorFakeChannel(), options);
 
-        Assert.That(channel.DeclaredExchanges, Does.Contain(options.DeadLetterExchangeName));
-        Assert.That(channel.DeclaredQueues, Does.Contain(options.QueueName.GetPoisonQueueName()));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredExchanges, Does.Contain(options.DeadLetterExchangeName));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredQueues, Does.Contain(options.QueueName.GetPoisonQueueName()));
     }
 
     [TestCase("")]
@@ -56,11 +52,10 @@ public class QueueConfiguratorTests
             QueueName = "q"
         };
 
-        var channel = new QueueConfiguratorFakeChannel();
-        QueueConfigurator.Configure(channel, options);
+        QueueConfigurator.Configure(() => new QueueConfiguratorFakeChannel(), options);
 
-        Assert.That(channel.DeclaredExchanges, Does.Not.Contain(options.DeadLetterExchangeName));
-        Assert.That(channel.DeclaredQueues, Does.Not.Contain(options.QueueName.GetPoisonQueueName()));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredExchanges, Does.Not.Contain(options.DeadLetterExchangeName));
+        Assert.That(QueueConfiguratorFakeChannel.DeclaredQueues, Does.Not.Contain(options.QueueName.GetPoisonQueueName()));
     }
 
     [Test]
@@ -73,10 +68,15 @@ public class QueueConfiguratorTests
             QueueName = "q"
         };
 
-        var channel = new QueueConfiguratorFakeChannel();
-        var result = QueueConfigurator.Configure(channel, options);
+        var result = QueueConfigurator.Configure(() => new QueueConfiguratorFakeChannel(), options);
 
-        channel.DeclaredQueuesArguments.TryGetValue(result.QueueName, out var args);
+        QueueConfiguratorFakeChannel.DeclaredQueuesArguments.TryGetValue(result.QueueName, out var args);
         Assert.That("dlx", Is.EqualTo(args?["x-dead-letter-exchange"]));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        QueueConfiguratorFakeChannel.ResetCounters();
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
@@ -111,7 +111,17 @@ namespace Lykke.RabbitMqBroker.Tests
 
             _subscriber.Start();
 
-            Assert.That(prefetchCount, Is.EqualTo(_connection.LatestChannel.PrefetchCount));
+            Assert.That(prefetchCount, Is.EqualTo(_connection.ConsumerChannel.PrefetchCount));
+        }
+
+
+        [TearDown]
+        public void TearDown()
+        {
+            _subscriber?.Stop();
+            _subscriber?.Dispose();
+            _connection?.Close();
+            _connection?.Dispose();
         }
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -111,7 +112,8 @@ namespace Lykke.RabbitMqBroker.Tests
 
             _subscriber.Start();
 
-            Assert.That(prefetchCount, Is.EqualTo(_connection.ConsumerChannel.PrefetchCount));
+            var consumerChannel = _connection.Channels.SingleOrDefault(x => x.PrefetchCount == prefetchCount);
+            Assert.That(consumerChannel, Is.Not.Null);
         }
 
 

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
@@ -112,7 +112,7 @@ namespace Lykke.RabbitMqBroker.Tests
 
             _subscriber.Start();
 
-            var consumerChannel = _connection.Channels.SingleOrDefault(x => x.PrefetchCount == prefetchCount);
+            var consumerChannel = _connection.Channels.SingleOrDefault(x => x?.PrefetchCount == prefetchCount);
             Assert.That(consumerChannel, Is.Not.Null);
         }
 


### PR DESCRIPTION
This change introduces a more secure approach to running the subscriber. Previously, a single channel was used to configure the queue and later to consume the queue. However, if an application level exception occurs during configuration, the channel is automatically closed. This may require a new channel to be created and queue configuration to continue before the queue is consumed, not to mention the risk to the subscriber who cannot consume on a closed channel, so the channel factory is now passed to the configurator instead of the channel itself.

This update is part of the Quorum Queue Migration Initiative.