### PR TITLE
feat(LT-5705): Add Cancellation Support and Logging to PoisonQueueHan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [[tbd]] (2024-10-21)
+
+### Changed
+- LT-5705: Add Cancellation Support and Logging to PoisonQueueHandler
+
 ## 15.3.0 (2024-10-18)
 
 ### Changed

--- a/src/Lykke.RabbitMqBroker/IPoisonQueueHandler.cs
+++ b/src/Lykke.RabbitMqBroker/IPoisonQueueHandler.cs
@@ -1,6 +1,8 @@
+using System.Threading;
+
 namespace Lykke.RabbitMqBroker;
 
 public interface IPoisonQueueHandler
 {
-    string TryPutMessagesBack();
+    string TryPutMessagesBack(CancellationToken cancellationToken = default);
 }

--- a/src/Lykke.RabbitMqBroker/ParallelExecutionGuardPoisonQueueDecorator.cs
+++ b/src/Lykke.RabbitMqBroker/ParallelExecutionGuardPoisonQueueDecorator.cs
@@ -14,5 +14,6 @@ public class ParallelExecutionGuardPoisonQueueDecorator : IPoisonQueueHandler
         _decoratee = decoratee ?? throw new ArgumentNullException(nameof(decoratee));
     }
 
-    public string TryPutMessagesBack() => _lock.Execute(_decoratee.TryPutMessagesBack, _timeout);
+    public string TryPutMessagesBack(CancellationToken cancellationToken = default) =>
+        _lock.Execute(() => _decoratee.TryPutMessagesBack(cancellationToken), _timeout);
 }

--- a/src/Lykke.RabbitMqBroker/PoisonQueueHandler.cs
+++ b/src/Lykke.RabbitMqBroker/PoisonQueueHandler.cs
@@ -1,29 +1,45 @@
+using System;
+using System.Threading;
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
-
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker;
 
+/// <summary>
+/// Requees messages from poison queue back to its original exchange.
+/// Checks if poison queue and exchange exists.
+/// Not thread safe.
+/// </summary>
 public class PoisonQueueHandler : IPoisonQueueHandler
 {
     private readonly string _connectionString;
     private readonly IConnectionProvider _connectionProvider;
     private readonly PoisonQueueConsumerConfigurationOptions _options;
+    private readonly ILogger<PoisonQueueConsumer> _consumerLogger;
     private uint _initialMessagesCount;
     private uint _messagesRequeued;
 
     public PoisonQueueHandler(
         string connectionString,
         IConnectionProvider connectionProvider,
-        PoisonQueueConsumerConfigurationOptions options)
+        PoisonQueueConsumerConfigurationOptions options,
+        ILoggerFactory loggerFactory
+    )
     {
-        _connectionString = connectionString;
-        _connectionProvider = connectionProvider;
-        _options = options;
+        _connectionString = string.IsNullOrEmpty(connectionString)
+            ? throw new ArgumentNullException(nameof(connectionString))
+            : connectionString;
+        _connectionProvider =
+            connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _consumerLogger =
+            loggerFactory?.CreateLogger<PoisonQueueConsumer>()
+            ?? throw new ArgumentNullException(nameof(loggerFactory));
     }
 
-    public string TryPutMessagesBack()
+    public string TryPutMessagesBack(CancellationToken cancellationToken = default)
     {
         using var connection = _connectionProvider.GetExclusive(_connectionString);
         using var channel = connection.CreateModel();
@@ -32,22 +48,35 @@ public class PoisonQueueHandler : IPoisonQueueHandler
 
         _messagesRequeued = _initialMessagesCount switch
         {
-            > 0 => new PoisonQueueConsumer(_options).Start(connection.CreateModel),
-            _ => default
+            > 0 => CreateConsumer().Start(connection.CreateModel, cancellationToken),
+            _ => 0,
         };
 
         return BuildResultText();
     }
 
+    private PoisonQueueConsumer CreateConsumer() => new(_options, _consumerLogger);
+
     private void EnsureResourcesExistOrThrow(IModel channel, out uint messagesCount)
     {
-        messagesCount = channel.QueueDeclarePassive(_options.PoisonQueueName.ToString()).MessageCount;
-        channel.ExchangeDeclarePassive(_options.ExchangeName.ToString());
+        try
+        {
+            messagesCount = channel.QueueDeclarePassive(_options.PoisonQueueName).MessageCount;
+            channel.ExchangeDeclarePassive(_options.ExchangeName);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Required queue [{_options.PoisonQueueName}] or exchange [{_options.ExchangeName}] does not exist",
+                ex
+            );
+        }
     }
 
-    private string BuildResultText() => _messagesRequeued switch
-    {
-        0 => string.Empty,
-        _ => $"Messages requeue finished. Initial number of messages {_initialMessagesCount}. Processed number of messages {_messagesRequeued}"
-    };
+    private string BuildResultText() =>
+        _messagesRequeued switch
+        {
+            0 => string.Empty,
+            _ => $"Messages requeue finished. Initial number of messages {_initialMessagesCount}. Processed number of messages {_messagesRequeued}",
+        };
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/ExchangeName.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/ExchangeName.cs
@@ -7,4 +7,5 @@ public record ExchangeName(string Value) : ResourceName(Validate(Value))
 {
     public static ExchangeName Create(string value) => new(value);
     public override string ToString() => base.ToString();
+    public static implicit operator string(ExchangeName name) => name.ToString();
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/PoisonQueueConsumerConfigurationOptions.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadStrategies/PoisonQueueConsumerConfigurationOptions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
 
 public sealed record PoisonQueueConsumerConfigurationOptions(

--- a/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueConsumer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueConsumer.cs
@@ -10,20 +10,16 @@ namespace Lykke.RabbitMqBroker.Subscriber;
 /// Consumer for poison queue to requeue messages back to the original exchange.
 /// Not thread safe.
 /// </summary>
-public class PoisonQueueConsumer
+public class PoisonQueueConsumer(
+    PoisonQueueConsumerConfigurationOptions options,
+    ILogger<PoisonQueueConsumer> logger
+)
 {
-    private readonly PoisonQueueConsumerConfigurationOptions _options;
+    private readonly PoisonQueueConsumerConfigurationOptions _options =
+        options ?? throw new ArgumentNullException(nameof(options));
+    private readonly ILogger<PoisonQueueConsumer> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
     private IModel _channel;
-    private readonly ILogger<PoisonQueueConsumer> _logger;
-
-    public PoisonQueueConsumer(
-        PoisonQueueConsumerConfigurationOptions options,
-        ILogger<PoisonQueueConsumer> logger
-    )
-    {
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
 
     public uint Start(Func<IModel> channelFactory) => Start(channelFactory, CancellationToken.None);
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueConsumer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueConsumer.cs
@@ -1,7 +1,7 @@
 using System;
-
+using System.Threading;
 using Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
-
+using Microsoft.Extensions.Logging;
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber;
@@ -14,33 +14,43 @@ public class PoisonQueueConsumer
 {
     private readonly PoisonQueueConsumerConfigurationOptions _options;
     private IModel _channel;
+    private readonly ILogger<PoisonQueueConsumer> _logger;
 
-    public PoisonQueueConsumer(PoisonQueueConsumerConfigurationOptions options)
+    public PoisonQueueConsumer(
+        PoisonQueueConsumerConfigurationOptions options,
+        ILogger<PoisonQueueConsumer> logger
+    )
     {
-        _options = options;
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public uint Start(Func<IModel> channelFactory)
+    public uint Start(Func<IModel> channelFactory) => Start(channelFactory, CancellationToken.None);
+
+    public uint Start(Func<IModel> channelFactory, CancellationToken cancellationToken)
     {
-        _channel = channelFactory();
+        ArgumentNullException.ThrowIfNull(channelFactory);
 
-        uint processedMessages = 0;
-        try
+        using (_channel = channelFactory())
         {
-            while (TryRequeueOne()) { processedMessages++; }
-        }
-        finally
-        {
-            _channel?.Close();
-            _channel.Dispose();
-        }
+            uint processedMessages = 0;
+            while (!cancellationToken.IsCancellationRequested && TryRequeueMessage())
+            {
+                processedMessages++;
+            }
 
-        return processedMessages;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning("Poison queue messages processing was canceled");
+            }
+
+            return processedMessages;
+        }
     }
 
-    private bool TryRequeueOne()
+    private bool TryRequeueMessage()
     {
-        var result = _channel.BasicGet(_options.PoisonQueueName.ToString(), false);
+        var result = _channel.BasicGet(_options.PoisonQueueName, false);
         if (result == null)
         {
             return false;
@@ -50,29 +60,42 @@ public class PoisonQueueConsumer
         {
             _channel.ConfirmSelect();
             _channel.BasicPublish(
-                _options.ExchangeName.ToString(),
-                _options.RoutingKey.ToString(),
+                _options.ExchangeName,
+                _options.RoutingKey,
                 CreatePropertiesFrom(result.BasicProperties),
-                Copy(result.Body));
+                Copy(result.Body)
+            );
             _channel.WaitForConfirmsOrDie();
             _channel.BasicAck(result.DeliveryTag, false);
             return true;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            LogRequeueError(result, ex);
             _channel.BasicNack(result.DeliveryTag, false, true);
             throw;
         }
+    }
+
+    private void LogRequeueError(BasicGetResult result, Exception ex)
+    {
+        _logger.LogError(
+            ex,
+            "Couldn't requeue message with delivery tag {DeliveryTag} from {PoisonQueue} to {Exchange}",
+            result.DeliveryTag,
+            _options.PoisonQueueName,
+            _options.ExchangeName
+        );
     }
 
     private IBasicProperties CreatePropertiesFrom(IBasicProperties source)
     {
         IBasicProperties properties = null;
 
-        if (!string.IsNullOrEmpty(_options.RoutingKey.ToString()))
+        if (!string.IsNullOrEmpty(_options.RoutingKey))
         {
             properties = _channel.CreateBasicProperties();
-            properties.Type = _options.RoutingKey.ToString();
+            properties.Type = _options.RoutingKey;
         }
 
         if (source?.Headers?.Count > 0)
@@ -87,7 +110,7 @@ public class PoisonQueueConsumer
     private static byte[] Copy(ReadOnlyMemory<byte> source)
     {
         var copy = new byte[source.Length];
-        Buffer.BlockCopy(source.ToArray(), 0, copy, 0, source.Length);
+        source.Span.CopyTo(copy);
         return copy;
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueName.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/PoisonQueueName.cs
@@ -13,4 +13,5 @@ public record PoisonQueueName(string Value) : QueueName(AddSuffix(Value))
 
     public static PoisonQueueName FromQueueName(QueueName queueName) => Create(queueName.Value);
     public override string ToString() => base.ToString();
+    public static implicit operator string(PoisonQueueName name) => name.ToString();
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/RoutingKey.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RoutingKey.cs
@@ -13,4 +13,5 @@ public record RoutingKey(string Value)
         };
     public static RoutingKey Empty => new(string.Empty);
     public override string ToString() => Value;
+    public static implicit operator string(RoutingKey key) => key.ToString();
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/PoisonQueueHandlerTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/PoisonQueueHandlerTests.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.MessageReadStrategies;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using NUnit.Framework;
 
 using RabbitMQ.Client;
@@ -685,7 +687,8 @@ public class PoisonQueueHandlerTests
             new PoisonQueueConsumerConfigurationOptions(
                 PoisonQueueName.Create("queue"),
                 ExchangeName.Create("exchange"),
-                RoutingKey.Empty));
+                RoutingKey.Empty),
+            NullLoggerFactory.Instance);
 
         var result = sut.TryPutMessagesBack();
 
@@ -701,7 +704,8 @@ public class PoisonQueueHandlerTests
             new PoisonQueueConsumerConfigurationOptions(
                 PoisonQueueName.Create("queue"),
                 ExchangeName.Create("exchange"),
-                RoutingKey.Empty));
+                RoutingKey.Empty),
+                NullLoggerFactory.Instance);
 
         var result = sut.TryPutMessagesBack();
 


### PR DESCRIPTION
Add Cancellation Support and Logging to PoisonQueueHandler

- Updated `IPoisonQueueHandler` interface to include `CancellationToken` in `TryPutMessagesBack` method for improved cancellation handling.
- Modified `ParallelExecutionGuardPoisonQueueDecorator` and `PoisonQueueHandler` to propagate and utilize the `CancellationToken`.
- Enhanced `PoisonQueueHandler` with logging capabilities using `ILogger` for better observability.
- Improved error handling in `PoisonQueueConsumer` with descriptive logging on requeue errors.
- Refactored `TryRequeueOne` to use `TryRequeueMessage` with cancellation support.
- Introduced implicit conversion operators for `ExchangeName`, `PoisonQueueName`, and `RoutingKey` to streamline usage.
- Updated tests to accommodate new `ILoggerFactory` dependency.
- Minor code cleanups and added missing null checks to constructors.

These changes improve the resilience and observability of the message requeue process from poison queue back to the original exchange.
