### PR TITLE
LT-5803-lykke-rabbit-mq-broker-update-message-pack-to-2-x-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [[tbd]] (2024-10-22)
+
+### Changed
+- Upgraded MessagePack library to version 2.5.187, introducing BREAKING CHANGES that required adjustments in how MessagePack is utilized.
+- Added asynchronous methods to serilizer and deserializer interfaces.
+- Added serializer and desiializer constructors that accept `MessagePackSerializerOptions` instead of `IFormatterResolver`.
+
+This update covers MessagePack's breaking changes and encapsulates them in the library, so the library's users don't have to worry about them. However, if the deserilization was used before with `readStrict` option equal to `true`, the behavior will be different now. The option `readStrict` is not supported anymore, and the deserialization will be NOT strict by default. For strict deserialization implement custom deserializer.
+
 ## 15.4.0 (2024-10-21)
 
 ### Changed

--- a/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
+++ b/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="MessagePack" Version="1.9.11" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
+++ b/src/Lykke.RabbitMqBroker/Lykke.RabbitMqBroker.csproj
@@ -29,8 +29,9 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="protobuf-net" Version="2.3.13" />

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/IRabbitMqSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/IRabbitMqSerializer.cs
@@ -10,7 +10,10 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
     public interface IRabbitMqSerializer<in TMessageModel>
     {
         byte[] Serialize(TMessageModel model);
-        Task<byte[]> SerializeAsync(TMessageModel model, CancellationToken cancellationToken = default);
+        Task<byte[]> SerializeAsync(
+            TMessageModel model,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(Serialize(model));
         SerializationFormat SerializationFormat { get; }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/IRabbitMqSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/IRabbitMqSerializer.cs
@@ -2,13 +2,15 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 
-using Lykke.RabbitMqBroker.Logging;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Lykke.RabbitMqBroker.Publisher.Serializers
 {
     public interface IRabbitMqSerializer<in TMessageModel>
     {
         byte[] Serialize(TMessageModel model);
+        Task<byte[]> SerializeAsync(TMessageModel model, CancellationToken cancellationToken = default);
         SerializationFormat SerializationFormat { get; }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/JsonMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/JsonMessageSerializer.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Lykke.RabbitMqBroker.Logging;
 using Newtonsoft.Json;
 
 namespace Lykke.RabbitMqBroker.Publisher.Serializers
@@ -14,28 +15,21 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
         private readonly Encoding _encoding;
         private readonly JsonSerializerSettings _settings;
 
-        public JsonMessageSerializer() :
-            this(null, null)
-        {
-        }
+        public JsonMessageSerializer()
+            : this(null, null) { }
 
-        public JsonMessageSerializer(Encoding encoding) :
-            this(encoding, null)
-        {
-        }
+        public JsonMessageSerializer(Encoding encoding)
+            : this(encoding, null) { }
 
-        public JsonMessageSerializer(JsonSerializerSettings settings) :
-            this(null, settings)
-        {
-        }
+        public JsonMessageSerializer(JsonSerializerSettings settings)
+            : this(null, settings) { }
 
         public JsonMessageSerializer(Encoding encoding, JsonSerializerSettings settings)
         {
             _encoding = encoding ?? Encoding.UTF8;
-            _settings = settings ?? new JsonSerializerSettings
-            {
-                DateTimeZoneHandling = DateTimeZoneHandling.Utc
-            };
+            _settings =
+                settings
+                ?? new JsonSerializerSettings { DateTimeZoneHandling = DateTimeZoneHandling.Utc };
         }
 
         public byte[] Serialize(TMessage model)
@@ -44,6 +38,11 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
 
             return _encoding.GetBytes(serialized);
         }
+
+        public Task<byte[]> SerializeAsync(
+            TMessage model,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(Serialize(model));
 
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Json;
     }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/JsonMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/JsonMessageSerializer.cs
@@ -39,11 +39,6 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
             return _encoding.GetBytes(serialized);
         }
 
-        public Task<byte[]> SerializeAsync(
-            TMessage model,
-            CancellationToken cancellationToken = default
-        ) => Task.FromResult(Serialize(model));
-
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Json;
     }
 }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/MessagePackMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/MessagePackMessageSerializer.cs
@@ -2,37 +2,52 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
 using JetBrains.Annotations;
-using Lykke.RabbitMqBroker.Logging;
 using MessagePack;
 
-namespace Lykke.RabbitMqBroker.Publisher.Serializers
+namespace Lykke.RabbitMqBroker.Publisher.Serializers;
+
+/// <summary>
+/// Uses MessagePack to serialize the message.
+/// </summary>
+[PublicAPI]
+public class MessagePackMessageSerializer<TMessage> : IRabbitMqSerializer<TMessage>
 {
+    private readonly MessagePackSerializerOptions _options;
+
     /// <summary>
-    /// Uses MessagePack to serialize the message
+    /// If resolver is not specified it uses <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
     /// </summary>
-    [PublicAPI]
-    public class MessagePackMessageSerializer<TMessage> : IRabbitMqSerializer<TMessage>
+    /// <param name="formatResolver"></param>
+    public MessagePackMessageSerializer(IFormatterResolver formatResolver = null)
     {
-        private readonly IFormatterResolver _formatResolver;
-
-        public MessagePackMessageSerializer(IFormatterResolver formatResolver = null)
+        _options = formatResolver switch
         {
-            _formatResolver = formatResolver;
-        }
-
-        public byte[] Serialize(TMessage model)
-        {
-            using (var stream = new MemoryStream())
-            {
-                MessagePackSerializer.Serialize(stream, model, _formatResolver);
-
-                stream.Flush();
-
-                return stream.ToArray();
-            }
-        }
-
-        public SerializationFormat SerializationFormat { get; } = SerializationFormat.Messagepack;
+            null => MessagePack.Resolvers.ContractlessStandardResolver.Options,
+            _ => MessagePackSerializerOptions.Standard.WithResolver(formatResolver)
+        };
     }
+
+    /// <summary>
+    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    public MessagePackMessageSerializer(MessagePackSerializerOptions options = null)
+    {
+        _options = options ?? MessagePackSerializerOptions.Standard;
+    }
+
+    public byte[] Serialize(TMessage model) => MessagePackSerializer.Serialize(model, _options);
+
+    public async Task<byte[]> SerializeAsync(TMessage model, CancellationToken cancellationToken = default)
+    {
+        await using var stream = new MemoryStream();
+        await MessagePackSerializer.SerializeAsync(stream, model, _options, cancellationToken);
+        return stream.ToArray();
+    }
+
+    public SerializationFormat SerializationFormat { get; } = SerializationFormat.Messagepack;
 }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/MessagePackMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/MessagePackMessageSerializer.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-
 using JetBrains.Annotations;
 using MessagePack;
 
@@ -19,22 +18,28 @@ public class MessagePackMessageSerializer<TMessage> : IRabbitMqSerializer<TMessa
     private readonly MessagePackSerializerOptions _options;
 
     /// <summary>
-    /// If resolver is not specified it uses <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
+    /// Create an instance of <see cref="MessagePackMessageSerializer{TMessage}"/>.
+    /// Kept for backward compatibility.
     /// </summary>
-    /// <param name="formatResolver"></param>
+    /// <param name="formatResolver">
+    /// If resolver is not specified it uses 
+    /// <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
+    /// </param>
     public MessagePackMessageSerializer(IFormatterResolver formatResolver = null)
     {
         _options = formatResolver switch
         {
             null => MessagePack.Resolvers.ContractlessStandardResolver.Options,
-            _ => MessagePackSerializerOptions.Standard.WithResolver(formatResolver)
+            _ => MessagePackSerializerOptions.Standard.WithResolver(formatResolver),
         };
     }
 
     /// <summary>
-    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// Create an instance of <see cref="MessagePackMessageSerializer{TMessage}"/>.
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">
+    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// </param>
     public MessagePackMessageSerializer(MessagePackSerializerOptions options = null)
     {
         _options = options ?? MessagePackSerializerOptions.Standard;
@@ -42,7 +47,10 @@ public class MessagePackMessageSerializer<TMessage> : IRabbitMqSerializer<TMessa
 
     public byte[] Serialize(TMessage model) => MessagePackSerializer.Serialize(model, _options);
 
-    public async Task<byte[]> SerializeAsync(TMessage model, CancellationToken cancellationToken = default)
+    public async Task<byte[]> SerializeAsync(
+        TMessage model,
+        CancellationToken cancellationToken = default
+    )
     {
         await using var stream = new MemoryStream();
         await MessagePackSerializer.SerializeAsync(stream, model, _options, cancellationToken);

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/ProtobufMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/ProtobufMessageSerializer.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Lykke.RabbitMqBroker.Logging;
 
 namespace Lykke.RabbitMqBroker.Publisher.Serializers
 {
@@ -16,13 +17,15 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
         /// <inheritdoc />
         public byte[] Serialize(TMessage model)
         {
-            using (var stream = new MemoryStream())
-            {
-                ProtoBuf.Serializer.Serialize(stream, model);
-                stream.Flush();
-                return stream.ToArray();
-            }
+            using var stream = new MemoryStream();
+            ProtoBuf.Serializer.Serialize(stream, model);
+            return stream.ToArray();
         }
+
+        public Task<byte[]> SerializeAsync(
+            TMessage model,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(Serialize(model));
 
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Protobuf;
     }

--- a/src/Lykke.RabbitMqBroker/Publisher/Serializers/ProtobufMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/Serializers/ProtobufMessageSerializer.cs
@@ -22,11 +22,6 @@ namespace Lykke.RabbitMqBroker.Publisher.Serializers
             return stream.ToArray();
         }
 
-        public Task<byte[]> SerializeAsync(
-            TMessage model,
-            CancellationToken cancellationToken = default
-        ) => Task.FromResult(Serialize(model));
-
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Protobuf;
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
 {
@@ -11,5 +13,11 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
         {
             return Encoding.UTF8.GetString(data);
         }
+
+        public Task<string> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Deserialize(data));
+        }
+
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
@@ -13,11 +13,5 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
         {
             return Encoding.UTF8.GetString(data);
         }
-
-        public Task<string> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(Deserialize(data));
-        }
-
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -55,6 +58,11 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
 
                 return _primaryDeserializer.Deserialize(data);
             }
+        }
+
+        public Task<TMessage> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Deserialize(data));
         }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
@@ -59,10 +59,5 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
                 return _primaryDeserializer.Deserialize(data);
             }
         }
-
-        public Task<TMessage> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(Deserialize(data));
-        }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -12,6 +11,7 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
     public interface IMessageDeserializer<TModel>
     {
         TModel Deserialize(byte[] data);
-        Task<TModel> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default);
+        Task<TModel> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Deserialize(data));
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
 {
     [PublicAPI]
-    public interface IMessageDeserializer<out TModel>
+    public interface IMessageDeserializer<TModel>
     {
         TModel Deserialize(byte[] data);
+        Task<TModel> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
@@ -3,6 +3,8 @@
 
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
@@ -14,28 +16,25 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
         private readonly Encoding _encoding;
         private readonly JsonSerializer _serializer;
 
-        public JsonMessageDeserializer() :
-            this(null, null)
-        {
-        }
+        public JsonMessageDeserializer()
+            : this(null, null) { }
 
-        public JsonMessageDeserializer(Encoding encoding) :
-            this(encoding, null)
-        {
-        }
+        public JsonMessageDeserializer(Encoding encoding)
+            : this(encoding, null) { }
 
-        public JsonMessageDeserializer(JsonSerializerSettings settings) :
-            this(null, settings)
-        {
-        }
+        public JsonMessageDeserializer(JsonSerializerSettings settings)
+            : this(null, settings) { }
 
         public JsonMessageDeserializer(Encoding encoding, JsonSerializerSettings settings)
         {
             _encoding = encoding ?? Encoding.UTF8;
-            _serializer = JsonSerializer.Create(settings ?? new JsonSerializerSettings
-            {
-                DateTimeZoneHandling = DateTimeZoneHandling.Utc
-            });
+            _serializer = JsonSerializer.Create(
+                settings
+                    ?? new JsonSerializerSettings
+                    {
+                        DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                    }
+            );
         }
 
         public TMessage Deserialize(byte[] data)
@@ -47,5 +46,10 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
                 return _serializer.Deserialize<TMessage>(jsonReader);
             }
         }
+
+        public Task<TMessage> DeserializeAsync(
+            byte[] data,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(Deserialize(data));
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
@@ -46,10 +46,5 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
                 return _serializer.Deserialize<TMessage>(jsonReader);
             }
         }
-
-        public Task<TMessage> DeserializeAsync(
-            byte[] data,
-            CancellationToken cancellationToken = default
-        ) => Task.FromResult(Deserialize(data));
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
@@ -20,8 +20,13 @@ public class MessagePackMessageDeserializer<TMessage> : IMessageDeserializer<TMe
     private readonly MessagePackSerializerOptions _options;
 
     /// <summary>
-    /// If resolver is not specified it uses <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
+    /// Create an instance of <see cref="MessagePackMessageDeserializer{TMessage}"/>.
+    /// Kept for backward compatibility.
     /// </summary>
+    /// <param name="formatterResolver">
+    /// If resolver is not specified it uses 
+    /// <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
+    /// </param>
     public MessagePackMessageDeserializer(IFormatterResolver formatterResolver)
     {
         _options = formatterResolver switch
@@ -32,9 +37,11 @@ public class MessagePackMessageDeserializer<TMessage> : IMessageDeserializer<TMe
     }
 
     /// <summary>
-    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// Create an instance of <see cref="MessagePackMessageDeserializer{TMessage}"/>.
     /// </summary>
-    /// <param name="options"></param>
+    /// <param name="options">
+    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// </param>
     public MessagePackMessageDeserializer(MessagePackSerializerOptions options = null)
     {
         _options = options ?? MessagePackSerializerOptions.Standard;

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
@@ -2,35 +2,52 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
 using JetBrains.Annotations;
+
 using MessagePack;
 
-namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
+namespace Lykke.RabbitMqBroker.Subscriber.Deserializers;
+
+/// <summary>
+/// Uses MessagePack to deserialize the message
+/// </summary>
+[PublicAPI]
+public class MessagePackMessageDeserializer<TMessage> : IMessageDeserializer<TMessage>
 {
+    private readonly MessagePackSerializerOptions _options;
+
     /// <summary>
-    /// Uses MessagePack to deserialize the message
+    /// If resolver is not specified it uses <see cref="MessagePack.Resolvers.ContractlessStandardResolver.Options"/>.
     /// </summary>
-    [PublicAPI]
-    public class MessagePackMessageDeserializer<TMessage> : IMessageDeserializer<TMessage>
+    public MessagePackMessageDeserializer(IFormatterResolver formatterResolver)
     {
-        private readonly IFormatterResolver _formatterResolver;
-        private readonly bool _readStrict;
-
-        /// <summary>
-        /// Uses MessagePack to deserialize the message
-        /// </summary>
-        public MessagePackMessageDeserializer(IFormatterResolver formatterResolver = null, bool readStrict = false)
+        _options = formatterResolver switch
         {
-            _formatterResolver = formatterResolver;
-            _readStrict = readStrict;
-        }
+            null => MessagePack.Resolvers.ContractlessStandardResolver.Options,
+            _ => MessagePackSerializerOptions.Standard.WithResolver(formatterResolver),
+        };
+    }
 
-        public TMessage Deserialize(byte[] data)
-        {
-            using (var stream = new MemoryStream(data))
-            {
-                return MessagePackSerializer.Deserialize<TMessage>(stream, _formatterResolver, _readStrict);
-            }
-        }
+    /// <summary>
+    /// If options is not specified it uses <see cref="MessagePackSerializerOptions.Standard"/>.
+    /// </summary>
+    /// <param name="options"></param>
+    public MessagePackMessageDeserializer(MessagePackSerializerOptions options = null)
+    {
+        _options = options ?? MessagePackSerializerOptions.Standard;
+    }
+
+    public TMessage Deserialize(byte[] data) => MessagePackSerializer.Deserialize<TMessage>(data, _options);
+
+    public async Task<TMessage> DeserializeAsync(
+        byte[] data,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await using var stream = new MemoryStream(data);
+        return await MessagePackSerializer.DeserializeAsync<TMessage>(stream, _options, cancellationToken);
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -15,10 +17,13 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
         /// <inheritdoc />
         public TMessage Deserialize(byte[] data)
         {
-            using (var stream = new MemoryStream(data))
-            {
-                return ProtoBuf.Serializer.Deserialize<TMessage>(stream);
-            }
+            using var stream = new MemoryStream(data);
+            return ProtoBuf.Serializer.Deserialize<TMessage>(stream);
         }
+
+        public Task<TMessage> DeserializeAsync(
+            byte[] data,
+            CancellationToken cancellationToken = default
+        ) => Task.FromResult(Deserialize(data));
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
@@ -20,10 +20,5 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
             using var stream = new MemoryStream(data);
             return ProtoBuf.Serializer.Deserialize<TMessage>(stream);
         }
-
-        public Task<TMessage> DeserializeAsync(
-            byte[] data,
-            CancellationToken cancellationToken = default
-        ) => Task.FromResult(Deserialize(data));
     }
 }

--- a/src/TestInvoke/PublishExample/TestMessageSerializer.cs
+++ b/src/TestInvoke/PublishExample/TestMessageSerializer.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Lykke.RabbitMqBroker;
 using Lykke.RabbitMqBroker.Publisher.Serializers;
@@ -16,12 +14,6 @@ namespace TestInvoke.PublishExample
         {
             return Encoding.UTF8.GetBytes(model);
         }
-
-        public Task<byte[]> SerializeAsync(string model, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(Serialize(model));
-        }
-
 
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Unknown;
     }

--- a/src/TestInvoke/PublishExample/TestMessageSerializer.cs
+++ b/src/TestInvoke/PublishExample/TestMessageSerializer.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Lykke.RabbitMqBroker;
 using Lykke.RabbitMqBroker.Publisher.Serializers;
 
@@ -13,6 +16,12 @@ namespace TestInvoke.PublishExample
         {
             return Encoding.UTF8.GetBytes(model);
         }
+
+        public Task<byte[]> SerializeAsync(string model, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Serialize(model));
+        }
+
 
         public SerializationFormat SerializationFormat { get; } = SerializationFormat.Unknown;
     }

--- a/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
+++ b/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
@@ -15,11 +15,5 @@ namespace TestInvoke.SubscribeExample
         {
             return Encoding.UTF8.GetString(data);
         }
-
-        public Task<string> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(Deserialize(data));
-        }
-
     }
 }

--- a/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
+++ b/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Lykke.RabbitMqBroker.Subscriber.Deserializers;
 
 namespace TestInvoke.SubscribeExample
@@ -12,5 +15,11 @@ namespace TestInvoke.SubscribeExample
         {
             return Encoding.UTF8.GetString(data);
         }
+
+        public Task<string> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Deserialize(data));
+        }
+
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
@@ -41,13 +41,6 @@ namespace Lykke.RabbitMqBroker.Tests
             {
                 return Encoding.UTF8.GetBytes(model);
             }
-
-            public Task<byte[]> SerializeAsync(string model, CancellationToken cancellationToken = default)
-            {
-                return Task.FromResult(Serialize(model));
-            }
-
-
             public SerializationFormat SerializationFormat { get; } = SerializationFormat.Unknown;
         }
 

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 
 using JetBrains.Annotations;
@@ -40,6 +41,12 @@ namespace Lykke.RabbitMqBroker.Tests
             {
                 return Encoding.UTF8.GetBytes(model);
             }
+
+            public Task<byte[]> SerializeAsync(string model, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(Serialize(model));
+            }
+
 
             public SerializationFormat SerializationFormat { get; } = SerializationFormat.Unknown;
         }


### PR DESCRIPTION
- Upgraded MessagePack library to version 2.5.187, introducing BREAKING CHANGES that required adjustments in how MessagePack is utilized.
- Added asynchronous methods to serializer and deserializer interfaces.
- Added serializer and deserializer constructors that accept `MessagePackSerializerOptions` instead of `IFormatterResolver`.