### PR TITLE
feat(LT-6016): do not deserialize message before passing it to middle…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [[tbd]] ([[date]])
+
+### Changed
+- LT-6016: Add monitoring feature for listeners
+
+Stop deserializing the message before it enters the middleware pipeline. This change removes an unnecessary operation and extra parameter, and it avoids forcing the system to know the deserialization format in advance—something that should instead be handled by the actual message handler.
+
+Regarding the monitoring aspect, the issue is that monitoring messages are always JSON-serialized, even though subscribers may expect messages in various formats and might not be able to deserialize a JSON-formatted monitoring message, especially since such deserialization isn’t needed because of short-circuiting monitoring messages on earlier stages - with dedicated MonitoringMiddleware.
+
+Along with core feature update also updated public API for IMessageDeserializer to support body parameter as ReadOnlyMemory<byte> which is safer than just byte[].
+
+**BREAKING CHANGE**: The `RabbitMqSubscriber` class now has `EventHandler` and `CancellableEventHandler` with different contract: 
+* `Func<ReadOnlyMemory<byte>, Task>` instead of `Func<byte[], Task>`
+* `Func<ReadOnlyMemory<byte>, CancellationToken, Task>` instead of `Func<byte[], CancellationToken, Task>`
+
+
 ## 17.0.5 (2025-02-28)
 
 ### Changed

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/DefaultStringDeserializer.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
 {
@@ -13,5 +12,11 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
         {
             return Encoding.UTF8.GetString(data);
         }
+
+        public string Deserialize(ReadOnlyMemory<byte> data)
+        {
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/FormatMigrationMessageDeserializer.cs
@@ -52,12 +52,31 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
             {
                 // Switches to another deserializer and tries to deserialize
 
-                _primaryDeserializer = ReferenceEquals(_primaryDeserializer, _newFromatDeserializer) 
-                    ? _legacyFormatDeserializer 
+                _primaryDeserializer = ReferenceEquals(_primaryDeserializer, _newFromatDeserializer)
+                    ? _legacyFormatDeserializer
                     : _newFromatDeserializer;
 
                 return _primaryDeserializer.Deserialize(data);
             }
         }
+
+        public TMessage Deserialize(ReadOnlyMemory<byte> data)
+        {
+            try
+            {
+                return _primaryDeserializer.Deserialize(data);
+            }
+            catch
+            {
+                // Switches to another deserializer and tries to deserialize
+
+                _primaryDeserializer = ReferenceEquals(_primaryDeserializer, _newFromatDeserializer)
+                    ? _legacyFormatDeserializer
+                    : _newFromatDeserializer;
+
+                return _primaryDeserializer.Deserialize(data);
+            }
+        }
+
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/IMessageDeserializer.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -10,6 +12,8 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
     [PublicAPI]
     public interface IMessageDeserializer<TModel>
     {
+        TModel Deserialize(ReadOnlyMemory<byte> data);
+        [Obsolete("Use Deserialize(ReadOnlyMemory<byte>) instead")]
         TModel Deserialize(byte[] data);
         Task<TModel> DeserializeAsync(byte[] data, CancellationToken cancellationToken = default) =>
             Task.FromResult(Deserialize(data));

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/JsonMessageDeserializer.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+
 using JetBrains.Annotations;
+
 using Newtonsoft.Json;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -39,12 +40,18 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
 
         public TMessage Deserialize(byte[] data)
         {
-            using (var stream = new MemoryStream(data))
-            using (var reader = new StreamReader(stream, _encoding))
-            using (var jsonReader = new JsonTextReader(reader))
-            {
-                return _serializer.Deserialize<TMessage>(jsonReader);
-            }
+            using var stream = new MemoryStream(data);
+            using var reader = new StreamReader(stream, _encoding);
+            using var jsonReader = new JsonTextReader(reader);
+            return _serializer.Deserialize<TMessage>(jsonReader);
+        }
+
+        public TMessage Deserialize(ReadOnlyMemory<byte> data)
+        {
+            using var stream = new MemoryStream(data.ToArray());
+            using var reader = new StreamReader(stream, _encoding);
+            using var jsonReader = new JsonTextReader(reader);
+            return _serializer.Deserialize<TMessage>(jsonReader);
         }
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/MessagePackMessageDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,9 @@ public class MessagePackMessageDeserializer<TMessage> : IMessageDeserializer<TMe
     }
 
     public TMessage Deserialize(byte[] data) => MessagePackSerializer.Deserialize<TMessage>(data, _options);
+
+    public TMessage Deserialize(ReadOnlyMemory<byte> data) => MessagePackSerializer.Deserialize<TMessage>(data, _options);
+
 
     public async Task<TMessage> DeserializeAsync(
         byte[] data,

--- a/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Deserializers/ProtobufMessageDeserializer.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
@@ -20,5 +22,12 @@ namespace Lykke.RabbitMqBroker.Subscriber.Deserializers
             using var stream = new MemoryStream(data);
             return ProtoBuf.Serializer.Deserialize<TMessage>(stream);
         }
+
+        public TMessage Deserialize(ReadOnlyMemory<byte> data)
+        {
+            using var stream = new MemoryStream(data.ToArray());
+            return ProtoBuf.Serializer.Deserialize<TMessage>(stream);
+        }
+
     }
 }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/ActualHandlerMiddleware.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/ActualHandlerMiddleware.cs
@@ -6,24 +6,24 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
 {
     internal class ActualHandlerMiddleware<T> : IEventMiddleware<T>
     {
-        private readonly Func<T, Task> _eventHandler;
-        private readonly Func<T, CancellationToken, Task> _cancellableEventHandler;
+        private readonly Func<ReadOnlyMemory<byte>, Task> _eventHandler;
+        private readonly Func<ReadOnlyMemory<byte>, CancellationToken, Task> _cancellableEventHandler;
 
-        internal ActualHandlerMiddleware(Func<T, Task> eventHandler)
+        internal ActualHandlerMiddleware(Func<ReadOnlyMemory<byte>, Task> eventHandler)
         {
-            _eventHandler = eventHandler ?? throw new ArgumentNullException();
+            _eventHandler = eventHandler ?? throw new ArgumentNullException(nameof(eventHandler));
         }
 
-        internal ActualHandlerMiddleware(Func<T, CancellationToken, Task> cancellableEventHandler)
+        internal ActualHandlerMiddleware(Func<ReadOnlyMemory<byte>, CancellationToken, Task> cancellableEventHandler)
         {
-            _cancellableEventHandler = cancellableEventHandler ?? throw new ArgumentNullException();
+            _cancellableEventHandler = cancellableEventHandler ?? throw new ArgumentNullException(nameof(cancellableEventHandler));
         }
 
         public async Task ProcessAsync(IEventContext<T> context)
         {
             await (_cancellableEventHandler != null
-                ? _cancellableEventHandler(context.Event, context.CancellationToken)
-                : _eventHandler(context.Event));
+                ? _cancellableEventHandler(context.Body, context.CancellationToken)
+                : _eventHandler(context.Body));
             context.MessageAcceptor.Accept();
         }
     }

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/EventContext.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/EventContext.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using JetBrains.Annotations;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Middleware
@@ -13,7 +15,6 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
 
         public ReadOnlyMemory<byte> Body { get; }
         [CanBeNull] public IBasicProperties BasicProperties { get; }
-        public T Event { get; }
         public IMessageAcceptor MessageAcceptor { get; }
         public RabbitMqSubscriptionSettings Settings { get; }
         public CancellationToken CancellationToken { get; }
@@ -21,14 +22,12 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
         internal EventContext(
             ReadOnlyMemory<byte> body,
             [CanBeNull] IBasicProperties properties,
-            T evt,
             IMessageAcceptor ma,
             RabbitMqSubscriptionSettings settings,
             int middlewareQueueIndex,
             IMiddlewareQueue<T> middlewareQueue,
             CancellationToken cancellationToken)
         {
-            Event = evt;
             MessageAcceptor = ma;
             Settings = settings;
             CancellationToken = cancellationToken;
@@ -44,7 +43,6 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
             var contextForNext = new EventContext<T>(
                 Body,
                 BasicProperties,
-                Event,
                 MessageAcceptor,
                 Settings,
                 _middlewareQueueIndex + 1,

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IEventContext.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IEventContext.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using JetBrains.Annotations;
+
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber.Middleware
@@ -9,10 +11,8 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
     public interface IEventContext<out T>
     {
         ReadOnlyMemory<byte> Body { get; }
-        
-        [CanBeNull] IBasicProperties BasicProperties { get; }
 
-        T Event { get; }
+        [CanBeNull] IBasicProperties BasicProperties { get; }
 
         IMessageAcceptor MessageAcceptor { get; }
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IMiddlewareQueue.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/IMiddlewareQueue.cs
@@ -26,7 +26,6 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
         Task RunMiddlewaresAsync(
             ReadOnlyMemory<byte> body,
             [CanBeNull] IBasicProperties properties,
-            T evt,
             IMessageAcceptor ma,
             CancellationToken cancellationToken);
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/Middleware/MiddlewareQueue.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/Middleware/MiddlewareQueue.cs
@@ -39,14 +39,12 @@ namespace Lykke.RabbitMqBroker.Subscriber.Middleware
         public Task RunMiddlewaresAsync(
             ReadOnlyMemory<byte> body,
             [CanBeNull] IBasicProperties properties,
-            T evt,
             IMessageAcceptor ma,
             CancellationToken cancellationToken)
         {
             var context = new EventContext<T>(
                 body,
                 properties,
-                evt,
                 ma,
                 _settings,
                 0,

--- a/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
+++ b/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Lykke Corp.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Lykke.RabbitMqBroker.Subscriber.Deserializers;
 
@@ -15,5 +14,11 @@ namespace TestInvoke.SubscribeExample
         {
             return Encoding.UTF8.GetString(data);
         }
+
+        public string Deserialize(ReadOnlyMemory<byte> data)
+        {
+            return Encoding.UTF8.GetString(data.Span);
+        }
+
     }
 }

--- a/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
 using System.Threading;
+
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.Middleware;
 using Lykke.RabbitMqBroker.Subscriber.Middleware.Deduplication;
+
 using NSubstitute;
+
 using NUnit.Framework;
-using RabbitMQ.Client.Events;
-using RabbitMQ.Client.Framing;
 
 namespace Lykke.RabbitMqBroker.Tests.Deduplication
 {
@@ -30,7 +31,7 @@ namespace Lykke.RabbitMqBroker.Tests.Deduplication
         [Test]
         public void EnsureNotDuplicateAsync()
         {
-            var value = new byte[] {1, 2, 3 };
+            var value = new byte[] { 1, 2, 3 };
             var acceptor = Substitute.For<IMessageAcceptor>();
             var lastMiddleware = Substitute.For<IEventMiddleware<string>>();
             var middlewarequeue = new MiddlewareQueue<string>(_settings);
@@ -40,14 +41,12 @@ namespace Lykke.RabbitMqBroker.Tests.Deduplication
             middlewarequeue.RunMiddlewaresAsync(
                     value,
                     null,
-                    null,
                     acceptor,
                     CancellationToken.None)
                 .GetAwaiter().GetResult();
 
             middlewarequeue.RunMiddlewaresAsync(
                     value,
-                    null,
                     null,
                     acceptor,
                     CancellationToken.None)

--- a/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
@@ -4,11 +4,15 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.Middleware;
 using Lykke.RabbitMqBroker.Subscriber.Middleware.ErrorHandling;
+
 using Microsoft.Extensions.Logging.Abstractions;
+
 using NSubstitute;
+
 using NUnit.Framework;
 
 namespace Lykke.RabbitMqBroker.Tests
@@ -36,7 +40,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => Task.CompletedTask));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             acceptor.Received(1).Accept();
         }
@@ -51,7 +55,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => throw new Exception()));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             rootEventMiddlewareHandler.Received(1).ProcessAsync(Arg.Any<IEventContext<string>>());
         }

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubscriberTests.cs
@@ -51,7 +51,7 @@ namespace Lykke.RabbitMqBroker.Tests
         {
             _eventHandler = Substitute.For<Func<StubMessage, Task>>();
             _subscriber.Subscribe(_eventHandler);
-            Assert.That(_subscriber.EventHandler, Is.EqualTo(_eventHandler));
+            Assert.That(_subscriber.EventHandler, Is.Not.Null);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace Lykke.RabbitMqBroker.Tests
         {
             _cancellableEventHandler = Substitute.For<Func<StubMessage, CancellationToken, Task>>();
             _subscriber.Subscribe(_cancellableEventHandler);
-            Assert.That(_subscriber.CancellableEventHandler, Is.EqualTo(_cancellableEventHandler));
+            Assert.That(_subscriber.CancellableEventHandler, Is.Not.Null);
         }
 
         [Test]

--- a/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
@@ -4,11 +4,15 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Lykke.RabbitMqBroker.Subscriber;
 using Lykke.RabbitMqBroker.Subscriber.Middleware;
 using Lykke.RabbitMqBroker.Subscriber.Middleware.ErrorHandling;
+
 using Microsoft.Extensions.Logging.Abstractions;
+
 using NSubstitute;
+
 using NUnit.Framework;
 
 namespace Lykke.RabbitMqBroker.Tests
@@ -37,7 +41,7 @@ namespace Lykke.RabbitMqBroker.Tests
             middlewarequeue.AddMiddleware(_middleware);
             middlewarequeue.AddMiddleware(new ActualHandlerMiddleware<string>(_ => Task.CompletedTask));
 
-            middlewarequeue.RunMiddlewaresAsync(null, null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
+            middlewarequeue.RunMiddlewaresAsync(null, null, acceptor, CancellationToken.None).GetAwaiter().GetResult();
 
             acceptor.Received(1).Accept();
         }


### PR DESCRIPTION
The main change in this pull request is to stop deserializing the message before it enters the middleware pipeline. This change removes an unnecessary operation and extra parameter, and it avoids forcing the system to know the deserialization format in advance—something that should instead be handled by the actual message handler.

Regarding the monitoring aspect, the issue is that monitoring messages are always JSON-serialized, even though subscribers may expect messages in various formats and might not be able to deserialize a JSON-formatted monitoring message, especially since such deserialization isn’t needed because of short-circuiting monitoring messages on earlier stages - with dedicated `MonitoringMiddleware`.

Along with core feature update also updated public API for `IMessageDeserializer` to support body parameter as `ReadOnlyMemory<byte>` which is safer than just `byte[]`.